### PR TITLE
Evolução do portfólio: Arcade (Damas + Memória), Biblioteca de Recursos e terminal interativo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Possuo amplo histórico no gerenciamento de incidentes críticos (war rooms, P1/
 
 ---
 
+## 🕹️ Arcade & Biblioteca Aberta
+
+* **[Arcade](https://rebecanonato89.dev/#/arcade)** — Jogos implementados do zero no browser: **Go** (Monte Carlo), **Damas brasileiras** (minimax com poda alfa-beta, lei da maioria e dama voadora) e **Jogo da Memória**. Sem cadastro, sem instalação.
+* **[Recursos](https://rebecanonato89.dev/#/recursos)** — Curadoria de recursos gratuitos para devs: livros para download ([BibliotecaDev](https://github.com/KAYOKG/BibliotecaDev), Goalkicker, free-programming-books), roadmaps, ferramentas e cursos abertos.
+
+---
+
 ## 📜 Certificações Recentes
 
 * **Reinvention with Agentic AI** (Accenture, Dez 2025)

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container" :class="{ 'high-contrast-mode': isHighContrast, 'light-mode': isLightMode, 'app-mode': isGoRoute }">
+  <div class="container" :class="{ 'high-contrast-mode': isHighContrast, 'light-mode': isLightMode, 'app-mode': isGameRoute }">
     <a href="#main-content" class="skip-link" @click.prevent="skipToMain">Pular para o conteúdo principal</a>
 
     <aside class="a11y-toolbar" aria-label="Ferramentas de acessibilidade e tema">
@@ -35,13 +35,15 @@
         <ul v-if="$route.path === '/'">
           <li><a href="#about" @click.prevent="scrollToId('about')">Identidade</a></li>
           <li><a href="#experience" @click.prevent="scrollToId('experience')">Log Execução</a></li>
-          <li><a href="#education" @click.prevent="scrollToId('education')">Data Banks</a></li>
           <li><a href="#projects" @click.prevent="scrollToId('projects')">Deployments</a></li>
+          <li><router-link to="/arcade" class="nav-highlight">Arcade</router-link></li>
+          <li><router-link to="/recursos" class="nav-highlight">Recursos</router-link></li>
           <li><a href="#contact" @click.prevent="scrollToId('contact')">Uplink</a></li>
-          <li><router-link to="/go">Go Game</router-link></li>
         </ul>
         <ul v-else>
           <li><router-link to="/">&larr; Portfólio</router-link></li>
+          <li><router-link to="/arcade">Arcade</router-link></li>
+          <li><router-link to="/recursos">Recursos</router-link></li>
         </ul>
       </nav>
     </header>
@@ -66,8 +68,10 @@ export default {
     };
   },
   computed: {
-    isGoRoute() {
-      return this.$route.path === '/go';
+    // Rotas de jogo entram em "modo app": some o cabeçalho/rodapé do portfólio
+    // e o jogo ganha a tela inteira (cada jogo tem sua barra própria de volta).
+    isGameRoute() {
+      return ['/go', '/damas', '/memoria'].includes(this.$route.path);
     }
   },
   mounted() {
@@ -300,6 +304,7 @@ body:not(.light-mode):not(.high-contrast-mode) header {
 nav ul { list-style: none; display: flex; gap: var(--space-lg); }
 nav a { color: var(--text-muted); text-decoration: none; font-family: var(--font-ui); font-size: 1.1rem; text-transform: uppercase; transition: 0.3s; }
 nav a:hover { color: var(--cyan-core); text-shadow: 0 0 8px var(--cyan-dim); }
+nav a.nav-highlight { color: var(--cyan-core); }
 
 section { margin-bottom: var(--space-xl); }
 .section-title {

--- a/src/checkers/checkersAI.js
+++ b/src/checkers/checkersAI.js
@@ -1,0 +1,111 @@
+// IA de Damas: minimax com poda alfa-beta em 3 níveis.
+//  Nível 1: escolhe um lance aleatório entre os legais (captura continua obrigatória).
+//  Nível 2: minimax de profundidade 4.
+//  Nível 3: aprofundamento iterativo com orçamento de tempo (~900ms), até profundidade 10.
+
+import { getLegalMoves, applyMove, WHITE } from './checkersLogic.js';
+
+const MAN_VALUE = 100;
+const KING_VALUE = 270;
+
+// Avaliação sempre da perspectiva das brancas (positivo = melhor para brancas).
+function evaluate(board) {
+  let score = 0;
+  for (let pos = 0; pos < 64; pos++) {
+    const value = board[pos];
+    if (value === 0) continue;
+    const row = Math.floor(pos / 8);
+    const col = pos % 8;
+
+    if (value === 1) {
+      score += MAN_VALUE + (7 - row) * 4; // avanço em direção à promoção
+      if (row === 7) score += 6; // última linha protege contra damas inimigas
+    } else if (value === -1) {
+      score -= MAN_VALUE + row * 4;
+      if (row === 0) score -= 6;
+    } else if (value === 2) {
+      score += KING_VALUE;
+    } else if (value === -2) {
+      score -= KING_VALUE;
+    }
+
+    // Leve preferência pelo centro (mais mobilidade, menos emboscada na borda)
+    if (col >= 2 && col <= 5 && row >= 2 && row <= 5) {
+      score += value > 0 ? 3 : -3;
+    }
+  }
+  return score;
+}
+
+function minimax(board, colorToMove, depth, alpha, beta, deadline) {
+  if (deadline && Date.now() > deadline) throw new Error('timeout');
+
+  const moves = getLegalMoves(board, colorToMove);
+  if (moves.length === 0) {
+    // Quem está na vez e não tem lance, perdeu
+    return colorToMove === WHITE ? -100000 - depth : 100000 + depth;
+  }
+  if (depth === 0) return evaluate(board);
+
+  // Capturas maiores primeiro melhora a poda
+  moves.sort((a, b) => b.captures.length - a.captures.length);
+
+  if (colorToMove === WHITE) {
+    let best = -Infinity;
+    for (const move of moves) {
+      const score = minimax(applyMove(board, move), -colorToMove, depth - 1, alpha, beta, deadline);
+      if (score > best) best = score;
+      if (best > alpha) alpha = best;
+      if (alpha >= beta) break;
+    }
+    return best;
+  }
+
+  let best = Infinity;
+  for (const move of moves) {
+    const score = minimax(applyMove(board, move), -colorToMove, depth - 1, alpha, beta, deadline);
+    if (score < best) best = score;
+    if (best < beta) beta = best;
+    if (alpha >= beta) break;
+  }
+  return best;
+}
+
+function bestMoveAtDepth(board, color, moves, depth, deadline) {
+  let bestMove = moves[0];
+  let bestScore = color === WHITE ? -Infinity : Infinity;
+  for (const move of moves) {
+    const score = minimax(applyMove(board, move), -color, depth - 1, -Infinity, Infinity, deadline);
+    if (color === WHITE ? score > bestScore : score < bestScore) {
+      bestScore = score;
+      bestMove = move;
+    }
+  }
+  return bestMove;
+}
+
+export function chooseMove(board, color, level) {
+  const moves = getLegalMoves(board, color);
+  if (moves.length === 0) return null;
+  if (moves.length === 1) return moves[0];
+
+  if (level <= 1) {
+    return moves[Math.floor(Math.random() * moves.length)];
+  }
+
+  if (level === 2) {
+    return bestMoveAtDepth(board, color, moves, 4, null);
+  }
+
+  // Nível 3: aprofundamento iterativo com limite de tempo
+  const deadline = Date.now() + 900;
+  let best = bestMoveAtDepth(board, color, moves, 4, null);
+  for (let depth = 5; depth <= 10; depth++) {
+    try {
+      best = bestMoveAtDepth(board, color, moves, depth, deadline);
+    } catch (error) {
+      break; // estourou o orçamento de tempo: fica com a melhor da profundidade anterior
+    }
+  }
+  return best;
+}

--- a/src/checkers/checkersLogic.js
+++ b/src/checkers/checkersLogic.js
@@ -1,0 +1,215 @@
+// Lógica de Damas (regras brasileiras) implementada do zero, sem bibliotecas.
+// Tabuleiro 8x8 representado como array de 64 posições (índice = linha * 8 + coluna).
+// Apenas as casas escuras ((linha + coluna) % 2 === 1) são jogáveis.
+//
+// Valores das casas:
+//   0  vazio
+//   1  pedra branca   2  dama branca   (humano, parte de baixo, sobe)
+//  -1  pedra preta   -2  dama preta    (máquina, parte de cima, desce)
+//
+// Regras implementadas:
+//  - Captura obrigatória, incluindo captura para trás pelas pedras simples.
+//  - Lei da maioria: entre as capturas possíveis, vale a que toma mais peças.
+//  - Dama voadora: move e captura a qualquer distância na diagonal.
+//  - Peças capturadas só saem do tabuleiro no fim do lance (bloqueiam o caminho
+//    e não podem ser puladas duas vezes).
+//  - Promoção apenas quando a pedra TERMINA o lance na última linha.
+
+export const SIZE = 8;
+export const WHITE = 1;
+export const BLACK = -1;
+
+const DIRS = [
+  [-1, -1], [-1, 1],
+  [1, -1], [1, 1],
+];
+
+export function createInitialBoard() {
+  const board = new Array(64).fill(0);
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 8; col++) {
+      if ((row + col) % 2 === 1) board[row * 8 + col] = -1;
+    }
+  }
+  for (let row = 5; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      if ((row + col) % 2 === 1) board[row * 8 + col] = 1;
+    }
+  }
+  return board;
+}
+
+export function rowOf(index) { return Math.floor(index / 8); }
+export function colOf(index) { return index % 8; }
+
+function inBoard(row, col) {
+  return row >= 0 && row < 8 && col >= 0 && col < 8;
+}
+
+function colorOf(value) {
+  if (value > 0) return WHITE;
+  if (value < 0) return BLACK;
+  return 0;
+}
+
+function isKing(value) { return value === 2 || value === -2; }
+
+// --- Capturas de pedra simples (pula casa adjacente, pra frente ou pra trás) ---
+function manCaptureSequences(board, pos, color, captured, path) {
+  const sequences = [];
+  const row = rowOf(pos);
+  const col = colOf(pos);
+
+  for (const [dr, dc] of DIRS) {
+    const midRow = row + dr, midCol = col + dc;
+    const landRow = row + 2 * dr, landCol = col + 2 * dc;
+    if (!inBoard(landRow, landCol)) continue;
+
+    const mid = midRow * 8 + midCol;
+    const land = landRow * 8 + landCol;
+    if (colorOf(board[mid]) !== -color || captured.includes(mid)) continue;
+    if (board[land] !== 0) continue;
+
+    const nextCaptured = [...captured, mid];
+    const nextPath = [...path, land];
+    const deeper = manCaptureSequences(board, land, color, nextCaptured, nextPath);
+    if (deeper.length > 0) {
+      sequences.push(...deeper);
+    } else {
+      sequences.push({ path: nextPath, captures: nextCaptured });
+    }
+  }
+  return sequences;
+}
+
+// --- Capturas de dama (voadora: varre a diagonal, pousa em qualquer casa livre após a peça) ---
+function kingCaptureSequences(board, pos, color, captured, path) {
+  const sequences = [];
+  const row = rowOf(pos);
+  const col = colOf(pos);
+
+  for (const [dr, dc] of DIRS) {
+    let r = row + dr, c = col + dc;
+    // Avança pelas casas vazias até achar a primeira peça na diagonal
+    while (inBoard(r, c) && board[r * 8 + c] === 0) { r += dr; c += dc; }
+    if (!inBoard(r, c)) continue;
+
+    const target = r * 8 + c;
+    // Peça própria ou já capturada neste lance bloqueia a diagonal
+    if (colorOf(board[target]) !== -color || captured.includes(target)) continue;
+
+    // Casas de pouso: todas as vazias imediatamente após a peça capturada
+    let lr = r + dr, lc = c + dc;
+    while (inBoard(lr, lc) && board[lr * 8 + lc] === 0) {
+      const land = lr * 8 + lc;
+      const nextCaptured = [...captured, target];
+      const nextPath = [...path, land];
+      const deeper = kingCaptureSequences(board, land, color, nextCaptured, nextPath);
+      if (deeper.length > 0) {
+        sequences.push(...deeper);
+      } else {
+        sequences.push({ path: nextPath, captures: nextCaptured });
+      }
+      lr += dr; lc += dc;
+    }
+  }
+  return sequences;
+}
+
+function captureSequencesFor(board, pos) {
+  const value = board[pos];
+  const color = colorOf(value);
+  // A peça sai da origem durante o lance (a casa fica livre para pouso)
+  const working = board.slice();
+  working[pos] = 0;
+  return isKing(value)
+    ? kingCaptureSequences(working, pos, color, [], [])
+    : manCaptureSequences(working, pos, color, [], []);
+}
+
+function simpleMovesFor(board, pos) {
+  const value = board[pos];
+  const color = colorOf(value);
+  const row = rowOf(pos);
+  const col = colOf(pos);
+  const moves = [];
+
+  if (isKing(value)) {
+    for (const [dr, dc] of DIRS) {
+      let r = row + dr, c = col + dc;
+      while (inBoard(r, c) && board[r * 8 + c] === 0) {
+        moves.push({ from: pos, path: [r * 8 + c], captures: [] });
+        r += dr; c += dc;
+      }
+    }
+  } else {
+    // Pedra simples só anda pra frente (branca sobe, preta desce)
+    const forward = color === WHITE ? -1 : 1;
+    for (const dc of [-1, 1]) {
+      const r = row + forward, c = col + dc;
+      if (inBoard(r, c) && board[r * 8 + c] === 0) {
+        moves.push({ from: pos, path: [r * 8 + c], captures: [] });
+      }
+    }
+  }
+  return moves;
+}
+
+// Retorna todos os lances legais de `color`, já aplicando captura obrigatória
+// e a lei da maioria (só valem as sequências com o número máximo de capturas).
+export function getLegalMoves(board, color) {
+  const captureMoves = [];
+  for (let pos = 0; pos < 64; pos++) {
+    if (colorOf(board[pos]) !== color) continue;
+    for (const seq of captureSequencesFor(board, pos)) {
+      captureMoves.push({ from: pos, path: seq.path, captures: seq.captures });
+    }
+  }
+
+  if (captureMoves.length > 0) {
+    const max = Math.max(...captureMoves.map((m) => m.captures.length));
+    return captureMoves.filter((m) => m.captures.length === max);
+  }
+
+  const moves = [];
+  for (let pos = 0; pos < 64; pos++) {
+    if (colorOf(board[pos]) !== color) continue;
+    moves.push(...simpleMovesFor(board, pos));
+  }
+  return moves;
+}
+
+export function applyMove(board, move) {
+  const next = board.slice();
+  const value = next[move.from];
+  next[move.from] = 0;
+  for (const captured of move.captures) next[captured] = 0;
+
+  const destination = move.path[move.path.length - 1];
+  const destRow = rowOf(destination);
+  const promotes =
+    !isKing(value) &&
+    ((colorOf(value) === WHITE && destRow === 0) ||
+      (colorOf(value) === BLACK && destRow === 7));
+
+  next[destination] = promotes ? value * 2 : value;
+  return next;
+}
+
+export function countPieces(board, color) {
+  let men = 0, kings = 0;
+  for (const value of board) {
+    if (colorOf(value) === color) {
+      if (isKing(value)) kings++; else men++;
+    }
+  }
+  return { men, kings, total: men + kings };
+}
+
+// Situação da partida para quem está na vez: 'playing' ou 'lost'
+// (sem peças ou sem lances legais = derrota de quem joga).
+export function getStatus(board, colorToMove) {
+  if (countPieces(board, colorToMove).total === 0) return 'lost';
+  if (getLegalMoves(board, colorToMove).length === 0) return 'lost';
+  return 'playing';
+}

--- a/src/components/HeroTerminal.vue
+++ b/src/components/HeroTerminal.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="term hud-card" @click="focusInput">
+    <div class="term-titlebar" aria-hidden="true">
+      <span class="term-dot term-dot--red"></span>
+      <span class="term-dot term-dot--yellow"></span>
+      <span class="term-dot term-dot--green"></span>
+      <span class="term-titlebar-text">rebeca@nonato.dev — bash</span>
+    </div>
+
+    <div class="term-screen" ref="screen" aria-live="polite">
+      <div v-for="(line, index) in lines" :key="index" class="term-line" :class="'term-line--' + line.type">
+        <template v-if="line.type === 'input'"><span class="term-prompt">{{ prompt }}</span> {{ line.text }}</template>
+        <template v-else>{{ line.text }}</template>
+      </div>
+      <form class="term-input-row" @submit.prevent="run">
+        <label class="term-prompt" for="term-input">{{ prompt }}</label>
+        <input
+          id="term-input"
+          ref="input"
+          v-model="command"
+          type="text"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-label="Terminal interativo: digite help para ver os comandos"
+          placeholder="digite 'help' e pressione Enter"
+        />
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+// Terminal interativo da home: um jeito diferente de navegar pelo portfólio.
+// Comandos de navegação usam o router; o restante imprime respostas na tela.
+export default {
+  name: 'HeroTerminal',
+  data() {
+    return {
+      prompt: 'visitante@rebeca.dev:~$',
+      command: '',
+      lines: [
+        { type: 'system', text: '// SISTEMA ONLINE — portfólio v3.0 carregado' },
+        { type: 'system', text: '// Engenheira de Software · Backend · Sistemas Distribuídos · Cloud' },
+        { type: 'output', text: "Digite 'help' para listar os comandos disponíveis." },
+      ],
+    };
+  },
+  methods: {
+    focusInput() {
+      // Só rouba o foco em clique direto; seleção de texto continua funcionando
+      if (!window.getSelection().toString()) this.$refs.input.focus();
+    },
+    print(text, type = 'output') {
+      this.lines.push({ type, text });
+    },
+    scrollDown() {
+      this.$nextTick(() => {
+        const screen = this.$refs.screen;
+        if (screen) screen.scrollTop = screen.scrollHeight;
+      });
+    },
+    run() {
+      const raw = this.command.trim();
+      this.command = '';
+      if (!raw) return;
+      this.print(raw, 'input');
+
+      const cmd = raw.toLowerCase();
+      const commands = {
+        help: () => {
+          this.print('Comandos disponíveis:');
+          this.print('  sobre      → quem sou eu');
+          this.print('  projetos   → deployments e cases');
+          this.print('  arcade     → jogos no browser (go, damas, memoria)');
+          this.print('  recursos   → biblioteca de livros, ferramentas e cursos');
+          this.print('  contato    → canais de contato');
+          this.print('  go | damas | memoria → abre o jogo direto');
+          this.print('  github | linkedin    → abre em nova aba');
+          this.print('  whoami | clear');
+        },
+        sobre: () => this.goToSection('about', 'Abrindo parâmetros do sistema…'),
+        projetos: () => this.goToSection('projects', 'Listando deployments…'),
+        contato: () => this.goToSection('contact', 'Estabelecendo conexão…'),
+        arcade: () => this.goToRoute('/arcade', 'Iniciando arcade…'),
+        recursos: () => this.goToRoute('/recursos', 'Abrindo biblioteca de recursos…'),
+        go: () => this.goToRoute('/go', 'Carregando tabuleiro de Go…'),
+        damas: () => this.goToRoute('/damas', 'Carregando tabuleiro de Damas…'),
+        memoria: () => this.goToRoute('/memoria', 'Embaralhando cartas…'),
+        github: () => this.openExternal('https://github.com/rebecanonato89'),
+        linkedin: () => this.openExternal('https://www.linkedin.com/in/rebecanonato89/'),
+        whoami: () => {
+          this.print('Rebeca Nonato — Engenheira de Software (+7 anos).');
+          this.print('Backend, sistemas distribuídos, AWS, Kafka, Clean Architecture.');
+          this.print('Também: professora universitária no passado, gamer de tabuleiro no presente.');
+        },
+        clear: () => { this.lines = []; },
+        sudo: () => this.print('visitante is not in the sudoers file. This incident will be reported. 😄'),
+        ls: () => this.print('sobre/  projetos/  arcade/  recursos/  contato/'),
+        pwd: () => this.print('/home/rebeca/portfolio'),
+      };
+
+      const action = commands[cmd] || commands[cmd.replace(/^\.\//, '')];
+      if (action) {
+        action();
+      } else {
+        this.print(`bash: ${raw}: comando não encontrado. Digite 'help'.`, 'error');
+      }
+      this.scrollDown();
+    },
+    goToSection(id, feedback) {
+      this.print(feedback);
+      if (this.$route.path !== '/') {
+        this.$router.push('/').then(() => this.scrollTo(id));
+      } else {
+        this.scrollTo(id);
+      }
+    },
+    scrollTo(id) {
+      this.$nextTick(() => {
+        const el = document.getElementById(id);
+        if (el) el.scrollIntoView({ behavior: 'smooth' });
+      });
+    },
+    goToRoute(path, feedback) {
+      this.print(feedback);
+      setTimeout(() => this.$router.push(path), 400);
+    },
+    openExternal(url) {
+      this.print(`Abrindo ${url} em nova aba…`);
+      window.open(url, '_blank', 'noopener,noreferrer');
+    },
+  },
+};
+</script>
+
+<style scoped>
+.term {
+  padding: 0;
+  overflow: hidden;
+  margin-bottom: var(--space-xl);
+  cursor: text;
+}
+.term-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px var(--space-md);
+  border-bottom: 1px solid var(--cyan-border);
+  background: var(--cyan-dim);
+}
+.term-dot {
+  width: 12px; height: 12px; border-radius: 50%;
+}
+.term-dot--red { background: #ff5f57; }
+.term-dot--yellow { background: #febc2e; }
+.term-dot--green { background: #28c840; }
+.term-titlebar-text {
+  margin-left: var(--space-sm);
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.term-screen {
+  padding: var(--space-md) var(--space-lg);
+  font-family: var(--font-code);
+  font-size: 0.85rem;
+  line-height: 1.7;
+  max-height: 300px;
+  overflow-y: auto;
+}
+.term-line { white-space: pre-wrap; word-break: break-word; color: var(--text-main); }
+.term-line--system { color: var(--cyan-core); }
+.term-line--input { color: var(--text-main); }
+.term-line--error { color: #ff6b6b; }
+.high-contrast-mode .term-line--error { color: #ffff00; }
+
+.term-prompt {
+  color: var(--cyan-core);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.term-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.term-input-row input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-main);
+  font-family: var(--font-code);
+  font-size: 0.85rem;
+  caret-color: var(--cyan-core);
+  min-width: 0;
+}
+.term-input-row input::placeholder { color: var(--text-muted); opacity: 0.7; }
+.term-input-row input:focus-visible { outline: none; box-shadow: none; }
+
+@media (max-width: 768px) {
+  .term-screen { max-height: 240px; padding: var(--space-md); }
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,10 +1,18 @@
 import { createRouter, createWebHashHistory } from 'vue-router';
 import Home from '../views/Home.vue';
 import GoGame from '../views/GoGame.vue';
+import CheckersGame from '../views/CheckersGame.vue';
+import MemoryGame from '../views/MemoryGame.vue';
+import Arcade from '../views/Arcade.vue';
+import Resources from '../views/Resources.vue';
 
 const routes = [
   { path: '/', name: 'home', component: Home },
-  { path: '/go', name: 'go-game', component: GoGame }
+  { path: '/arcade', name: 'arcade', component: Arcade },
+  { path: '/go', name: 'go-game', component: GoGame },
+  { path: '/damas', name: 'checkers-game', component: CheckersGame },
+  { path: '/memoria', name: 'memory-game', component: MemoryGame },
+  { path: '/recursos', name: 'resources', component: Resources },
 ];
 
 const router = createRouter({

--- a/src/views/Arcade.vue
+++ b/src/views/Arcade.vue
@@ -1,0 +1,98 @@
+<template>
+  <main id="main-content">
+    <section id="arcade" aria-labelledby="arcade-title">
+      <h2 id="arcade-title" class="section-title">Arcade // Jogos no Browser</h2>
+
+      <div class="hud-card arcade-intro">
+        <p>
+          Todos os jogos abaixo foram implementados <strong>do zero, sem bibliotecas de jogos</strong> —
+          regras, inteligência artificial e interface. Cada um é também um estudo de algoritmos:
+          Monte Carlo, minimax com poda alfa-beta e gerenciamento de estado. Jogue direto no navegador,
+          sem cadastro e sem instalação.
+        </p>
+      </div>
+
+      <div class="arcade-grid">
+        <article v-for="game in games" :key="game.title" class="hud-card arcade-card">
+          <div class="arcade-icon" aria-hidden="true">{{ game.icon }}</div>
+          <header class="card-header">
+            <h3 class="card-title">{{ game.title }}</h3>
+            <span class="card-period">{{ game.tag }}</span>
+          </header>
+          <p class="card-desc">{{ game.description }}</p>
+          <ul class="tech-list" aria-label="Técnicas utilizadas">
+            <li v-for="tech in game.stack" :key="tech" class="tech-tag">{{ tech }}</li>
+          </ul>
+          <router-link :to="game.route" class="btn-hud btn-hud--live">
+            Jogar agora <span class="sr-only"> ({{ game.title }})</span>
+          </router-link>
+        </article>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script>
+export default {
+  name: 'Arcade',
+  data() {
+    return {
+      games: [
+        {
+          icon: '⚫⚪',
+          title: 'Go (Baduk/Weiqi)',
+          tag: 'ESTRATÉGIA',
+          route: '/go',
+          description:
+            'O clássico jogo milenar de território. Regras completas: captura de grupos, ko, proibição de suicídio e contagem por área. Três níveis de máquina, do aleatório ao Monte Carlo com orçamento de tempo.',
+          stack: ['Monte Carlo', 'Flood Fill', 'Heurísticas'],
+        },
+        {
+          icon: '🔴⚪',
+          title: 'Damas Brasileiras',
+          tag: 'ESTRATÉGIA',
+          route: '/damas',
+          description:
+            'Regras oficiais brasileiras: captura obrigatória (inclusive para trás), lei da maioria, dama voadora e capturas em cadeia. A máquina calcula com minimax e poda alfa-beta em três profundidades.',
+          stack: ['Minimax', 'Poda Alfa-Beta', 'Busca Iterativa'],
+        },
+        {
+          icon: '🃏',
+          title: 'Memória — Stack Edition',
+          tag: 'CASUAL',
+          route: '/memoria',
+          description:
+            'Jogo da memória com as tecnologias do meu dia a dia. Três dificuldades (16, 24 ou 36 cartas), cronômetro, contador de jogadas e recorde pessoal salvo no navegador.',
+          stack: ['Vue 3', 'Animações CSS 3D', 'localStorage'],
+        },
+      ],
+    };
+  },
+};
+</script>
+
+<style scoped>
+.arcade-intro {
+  margin-bottom: var(--space-lg);
+}
+.arcade-intro p { color: var(--text-main); }
+
+.arcade-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-lg);
+}
+@media (min-width: 900px) {
+  .arcade-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.arcade-card {
+  position: relative;
+  overflow: hidden;
+}
+.arcade-icon {
+  font-size: 2rem;
+  margin-bottom: var(--space-sm);
+  filter: drop-shadow(0 0 8px var(--cyan-dim));
+}
+</style>

--- a/src/views/CheckersGame.vue
+++ b/src/views/CheckersGame.vue
@@ -1,0 +1,451 @@
+<template>
+  <main id="main-content">
+    <div class="dm-app-bar">
+      <router-link to="/arcade" class="dm-app-back" aria-label="Voltar ao arcade">&larr; Arcade</router-link>
+      <span class="dm-app-title">Damas</span>
+    </div>
+
+    <section id="checkers-game" aria-labelledby="checkers-title">
+      <h2 id="checkers-title" class="section-title">Damas — Humano vs Máquina</h2>
+
+      <div class="hud-card dm-intro" v-if="!started">
+        <p>
+          Damas nas <strong>regras brasileiras</strong>, implementadas do zero: captura obrigatória
+          (inclusive para trás pelas pedras), <strong>lei da maioria</strong> (vale a sequência que captura
+          mais peças), <strong>dama voadora</strong> e capturas em cadeia. A máquina joga com busca
+          minimax e poda alfa-beta.
+        </p>
+        <p>Você joga com as <strong>peças claras</strong> (parte de baixo) e começa. Clique numa peça e depois na casa de destino — em capturas múltiplas, clique casa por casa.</p>
+      </div>
+
+      <div class="hud-card dm-panel">
+        <div class="dm-controls-row">
+          <div class="dm-control-row">
+            <label for="dm-level">Nível da máquina</label>
+            <select id="dm-level" v-model.number="level">
+              <option :value="1">1 — Fácil (aleatória)</option>
+              <option :value="2">2 — Médio (minimax raso)</option>
+              <option :value="3">3 — Difícil (busca profunda)</option>
+            </select>
+          </div>
+          <button class="btn-hud btn-hud--live" @click="startNewGame">
+            {{ started ? 'Novo Jogo' : 'Iniciar Partida' }}
+          </button>
+          <button v-if="started && !gameOver" class="btn-hud" :disabled="isAIThinking" @click="resign">Desistir</button>
+        </div>
+
+        <template v-if="started">
+          <div class="dm-panel-divider" aria-hidden="true"></div>
+          <p class="dm-message" aria-live="polite">{{ message }}</p>
+          <div class="dm-counts">
+            <span>⛀ Você: {{ whiteCount.total }} peças ({{ whiteCount.kings }} damas)</span>
+            <span>⛂ Máquina: {{ blackCount.total }} peças ({{ blackCount.kings }} damas)</span>
+          </div>
+        </template>
+      </div>
+
+      <div v-if="started" class="hud-card dm-board-card">
+        <div class="dm-board" role="grid" aria-label="Tabuleiro de damas 8 por 8">
+          <button
+            v-for="index in 64"
+            :key="index - 1"
+            type="button"
+            class="dm-square"
+            :class="squareClasses(index - 1)"
+            role="gridcell"
+            :disabled="!isSquareClickable(index - 1)"
+            :aria-label="squareAriaLabel(index - 1)"
+            @click="onSquareClick(index - 1)"
+          >
+            <span v-if="displayBoard[index - 1] !== 0" class="dm-piece" :class="pieceClasses(index - 1)" aria-hidden="true">
+              <span v-if="Math.abs(displayBoard[index - 1]) === 2" class="dm-crown">♛</span>
+            </span>
+            <span v-if="isTargetSquare(index - 1)" class="dm-target" aria-hidden="true"></span>
+          </button>
+        </div>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script>
+import {
+  createInitialBoard,
+  getLegalMoves,
+  applyMove,
+  countPieces,
+  WHITE,
+  BLACK,
+} from '../checkers/checkersLogic.js';
+import { chooseMove } from '../checkers/checkersAI.js';
+
+export default {
+  name: 'CheckersGame',
+  data() {
+    return {
+      level: 2,
+      started: false,
+      board: [],
+      turn: WHITE,
+      selected: null,      // casa da peça escolhida pelo humano
+      candidates: [],      // lances legais da peça escolhida, filtrados pelo caminho já clicado
+      stepIndex: 0,        // quantas casas do caminho o humano já clicou
+      legalMoves: [],
+      lastMoveSquares: [], // origem + caminho do último lance (destaque visual)
+      isAIThinking: false,
+      gameOver: false,
+      message: '',
+      quietKingMoves: 0,   // lances de dama sem captura (regra de empate)
+    };
+  },
+  computed: {
+    whiteCount() { return countPieces(this.board, WHITE); },
+    blackCount() { return countPieces(this.board, BLACK); },
+    isHumanTurn() { return this.turn === WHITE && !this.gameOver && !this.isAIThinking; },
+    mustCapture() {
+      return this.legalMoves.length > 0 && this.legalMoves[0].captures.length > 0;
+    },
+    // Tabuleiro exibido: durante uma captura múltipla do humano, a peça aparece
+    // na casa intermediária já clicada (as capturadas só saem no fim do lance).
+    displayBoard() {
+      if (this.selected === null || this.stepIndex === 0) return this.board;
+      const shown = this.board.slice();
+      const current = this.candidates[0].path[this.stepIndex - 1];
+      shown[current] = shown[this.selected];
+      shown[this.selected] = 0;
+      return shown;
+    },
+  },
+  methods: {
+    startNewGame() {
+      this.board = createInitialBoard();
+      this.turn = WHITE;
+      this.started = true;
+      this.gameOver = false;
+      this.isAIThinking = false;
+      this.selected = null;
+      this.candidates = [];
+      this.stepIndex = 0;
+      this.lastMoveSquares = [];
+      this.quietKingMoves = 0;
+      this.refreshLegalMoves();
+      this.message = 'Sua vez. Você joga com as peças claras.';
+    },
+    refreshLegalMoves() {
+      this.legalMoves = getLegalMoves(this.board, this.turn);
+    },
+    isDark(index) {
+      return (Math.floor(index / 8) + (index % 8)) % 2 === 1;
+    },
+    squareClasses(index) {
+      return {
+        'dm-square--dark': this.isDark(index),
+        'dm-square--selected': this.currentPieceSquare() === index,
+        'dm-square--last': this.lastMoveSquares.includes(index),
+      };
+    },
+    pieceClasses(index) {
+      const value = this.displayBoard[index];
+      return {
+        'dm-piece--white': value > 0,
+        'dm-piece--black': value < 0,
+      };
+    },
+    // Casa onde está a peça em movimento (origem ou casa intermediária clicada)
+    currentPieceSquare() {
+      if (this.selected === null) return null;
+      if (this.stepIndex === 0) return this.selected;
+      return this.candidates[0].path[this.stepIndex - 1];
+    },
+    targetSquares() {
+      if (this.selected === null || this.gameOver || !this.isHumanTurn) return [];
+      return [...new Set(this.candidates.map((m) => m.path[this.stepIndex]))];
+    },
+    isTargetSquare(index) {
+      return this.targetSquares().includes(index);
+    },
+    isSquareClickable(index) {
+      if (!this.isHumanTurn) return false;
+      if (this.isTargetSquare(index)) return true;
+      // Só permite trocar de peça antes de iniciar a sequência de cliques
+      if (this.stepIndex === 0) {
+        return this.legalMoves.some((m) => m.from === index);
+      }
+      return false;
+    },
+    squareAriaLabel(index) {
+      const row = 8 - Math.floor(index / 8);
+      const col = String.fromCharCode(97 + (index % 8));
+      const value = this.displayBoard[index];
+      let piece = 'casa vazia';
+      if (value === 1) piece = 'sua pedra';
+      if (value === 2) piece = 'sua dama';
+      if (value === -1) piece = 'pedra da máquina';
+      if (value === -2) piece = 'dama da máquina';
+      return `${col}${row}: ${piece}`;
+    },
+    onSquareClick(index) {
+      if (!this.isHumanTurn) return;
+
+      if (this.isTargetSquare(index)) {
+        this.candidates = this.candidates.filter((m) => m.path[this.stepIndex] === index);
+        this.stepIndex++;
+        const pathLength = this.candidates[0].path.length;
+        if (this.stepIndex >= pathLength) {
+          this.playHumanMove(this.candidates[0]);
+        } else {
+          this.message = 'Captura em cadeia: continue clicando nas casas.';
+        }
+        return;
+      }
+
+      // Seleção (ou troca) de peça
+      const moves = this.legalMoves.filter((m) => m.from === index);
+      if (moves.length > 0) {
+        this.selected = index;
+        this.candidates = moves;
+        this.stepIndex = 0;
+        this.message = this.mustCapture
+          ? 'Captura obrigatória! Clique na casa de destino.'
+          : 'Clique na casa de destino.';
+      }
+    },
+    playHumanMove(move) {
+      this.executeMove(move);
+      this.selected = null;
+      this.candidates = [];
+      this.stepIndex = 0;
+      if (this.gameOver) return;
+      this.message = 'Máquina pensando…';
+      this.isAIThinking = true;
+      // setTimeout libera o navegador pra pintar o lance humano antes da busca da IA
+      setTimeout(() => this.playAIMove(), 350);
+    },
+    playAIMove() {
+      const move = chooseMove(this.board, BLACK, this.level);
+      this.isAIThinking = false;
+      if (!move) {
+        this.finish('Você venceu! A máquina não tem lances.');
+        return;
+      }
+      this.executeMove(move);
+      if (!this.gameOver) {
+        this.message = this.mustCapture
+          ? 'Sua vez — captura obrigatória!'
+          : 'Sua vez.';
+      }
+    },
+    executeMove(move) {
+      const movingValue = this.board[move.from];
+      this.board = applyMove(this.board, move);
+      this.lastMoveSquares = [move.from, ...move.path];
+
+      // Regra de empate: 40 lances seguidos de dama sem captura
+      if (move.captures.length === 0 && Math.abs(movingValue) === 2) {
+        this.quietKingMoves++;
+      } else {
+        this.quietKingMoves = 0;
+      }
+      if (this.quietKingMoves >= 40) {
+        this.finish('Empate: 40 lances de dama sem captura.');
+        return;
+      }
+
+      this.turn = -this.turn;
+      this.refreshLegalMoves();
+
+      if (this.legalMoves.length === 0) {
+        this.finish(this.turn === WHITE
+          ? 'A máquina venceu. Sem lances disponíveis para você.'
+          : 'Você venceu! A máquina ficou sem lances.');
+      }
+    },
+    finish(text) {
+      this.gameOver = true;
+      this.message = text;
+    },
+    resign() {
+      this.finish('Você desistiu. Vitória da máquina — bora de revanche?');
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dm-app-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 12px var(--space-lg);
+  margin: 0 calc(-1 * var(--space-lg)) var(--space-md);
+  background: var(--bg-surface);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--cyan-border);
+}
+.dm-app-back {
+  color: var(--cyan-core);
+  text-decoration: none;
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.dm-app-title {
+  font-family: var(--font-ui);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-main);
+  font-size: 0.95rem;
+}
+
+#checkers-title {
+  font-size: 1.3rem;
+  margin-bottom: 10px;
+}
+
+.dm-intro p {
+  margin-bottom: var(--space-sm);
+  color: var(--text-main);
+}
+.dm-intro p:last-child { margin-bottom: 0; }
+.dm-intro { margin-bottom: var(--space-md); }
+
+.dm-panel {
+  padding: 12px var(--space-lg);
+  gap: 6px;
+  margin-bottom: var(--space-md);
+}
+.dm-controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-md) var(--space-lg);
+}
+.dm-control-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.dm-control-row label {
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  color: var(--cyan-core);
+  text-transform: uppercase;
+}
+.dm-control-row select {
+  background: var(--bg-surface);
+  color: var(--text-main);
+  border: 1px solid var(--cyan-border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--font-read);
+  font-size: 0.9rem;
+}
+.dm-panel-divider {
+  border-top: 1px dashed var(--cyan-dim);
+  margin: var(--space-sm) 0;
+}
+.dm-message {
+  font-family: var(--font-ui);
+  font-size: 1.05rem;
+  color: var(--text-main);
+  min-height: 1.4em;
+}
+.dm-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  font-family: var(--font-code);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.dm-board-card {
+  padding: var(--space-md);
+  align-items: center;
+}
+.dm-board {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  width: min(92vw, 560px);
+  aspect-ratio: 1;
+  border: 2px solid var(--cyan-border);
+  box-shadow: 0 0 25px var(--cyan-dim);
+}
+.dm-square {
+  position: relative;
+  border: none;
+  padding: 0;
+  background: rgba(230, 240, 255, 0.08);
+  cursor: default;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.dm-square--dark {
+  background: rgba(0, 229, 255, 0.14);
+}
+.light-mode .dm-square { background: #e8eef6; }
+.light-mode .dm-square--dark { background: #9db8d4; }
+.dm-square:not(:disabled) { cursor: pointer; }
+.dm-square--selected {
+  outline: 2px solid var(--cyan-core);
+  outline-offset: -2px;
+}
+.dm-square--last {
+  box-shadow: inset 0 0 0 2px rgba(0, 229, 255, 0.45);
+}
+
+.dm-piece {
+  width: 76%;
+  height: 76%;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(0.9rem, 3.4vw, 1.5rem);
+}
+.dm-piece--white {
+  background: radial-gradient(circle at 33% 30%, #ffffff, #b8c6d4 70%);
+  border: 1px solid #8fa3b5;
+  color: #1a2733;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+.dm-piece--black {
+  background: radial-gradient(circle at 33% 30%, #3c4654, #0b111a 75%);
+  border: 1px solid #05080d;
+  color: #00e5ff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+.dm-crown { line-height: 1; }
+
+.dm-target {
+  position: absolute;
+  width: 34%;
+  height: 34%;
+  border-radius: 50%;
+  background: var(--cyan-core);
+  opacity: 0.55;
+  animation: dm-pulse 1.2s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes dm-pulse {
+  0%, 100% { transform: scale(0.85); opacity: 0.45; }
+  50% { transform: scale(1); opacity: 0.75; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dm-target { animation: none; }
+}
+
+.high-contrast-mode .dm-square { background: #1a1a1a; }
+.high-contrast-mode .dm-square--dark { background: #333300; }
+.high-contrast-mode .dm-target { background: #ffff00; }
+
+@media (max-width: 768px) {
+  .dm-app-bar { margin: 0 0 var(--space-md); }
+  .dm-board { width: min(96vw, 560px); }
+}
+</style>

--- a/src/views/GoGame.vue
+++ b/src/views/GoGame.vue
@@ -1,7 +1,7 @@
 <template>
   <main id="main-content">
     <div class="go-app-bar">
-      <router-link to="/" class="go-app-back" aria-label="Fechar e voltar ao portfólio">&larr; Portfólio</router-link>
+      <router-link to="/arcade" class="go-app-back" aria-label="Fechar e voltar ao arcade">&larr; Arcade</router-link>
       <span class="go-app-title">Go Game</span>
     </div>
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,7 @@
 <template>
   <main id="main-content">
+    <HeroTerminal />
+
     <section id="about" aria-labelledby="about-title">
       <h2 id="about-title" class="section-title">Parâmetros do Sistema</h2>
       <div class="hud-card">
@@ -45,26 +47,6 @@
     <section id="projects" aria-labelledby="projects-title">
       <h2 id="projects-title" class="section-title">Deployments & Cases</h2>
       <div class="project-grid">
-        <article class="hud-card">
-          <header class="card-header">
-            <h3 class="card-title">Go Game: IA de Weiqi/Baduk no Browser</h3>
-            <span class="card-period">Jul 2026</span>
-          </header>
-          <div class="card-desc">
-            <p>Jogo de Go (Baduk/Weiqi) implementado do zero, sem bibliotecas de terceiros para as regras: captura de grupos, proibição de suicídio, regra do ko, marcação de pedras mortas e contagem de território por área. Humano (Preto) contra máquina (Branco), com 3 níveis de IA: aleatória com heurística mínima, gulosa por avaliação de jogadas e Monte Carlo com orçamento de tempo.</p>
-          </div>
-          <ul class="tech-list" aria-label="Stack Tecnológica">
-            <li class="tech-tag">Vue 3</li>
-            <li class="tech-tag">JavaScript</li>
-            <li class="tech-tag">Monte Carlo</li>
-            <li class="tech-tag">Algoritmos de Jogos</li>
-          </ul>
-          <div style="display: flex; gap: var(--space-sm); flex-wrap: wrap;">
-            <router-link to="/go" class="btn-hud btn-hud--live">
-              Jogar agora <span class="sr-only"> (abre a página do jogo)</span>
-            </router-link>
-          </div>
-        </article>
         <article v-for="project in projectsData" :key="project.title" class="hud-card">
           <header class="card-header">
             <h3 class="card-title">{{ project.title }}</h3>
@@ -83,6 +65,34 @@
             </a>
           </div>
         </article>
+      </div>
+    </section>
+
+    <section id="arcade-preview" aria-labelledby="arcade-preview-title">
+      <h2 id="arcade-preview-title" class="section-title">Arcade // Jogue no Browser</h2>
+      <div class="hud-card">
+        <p class="card-desc" style="margin-bottom: var(--space-md);">
+          Jogos implementados do zero — regras, IA e interface — direto no navegador.
+          Go com Monte Carlo, Damas brasileiras com minimax e um jogo da memória para relaxar.
+        </p>
+        <div class="arcade-preview-row">
+          <router-link to="/go" class="btn-hud">⚫ Go</router-link>
+          <router-link to="/damas" class="btn-hud">🔴 Damas</router-link>
+          <router-link to="/memoria" class="btn-hud">🃏 Memória</router-link>
+          <router-link to="/arcade" class="btn-hud btn-hud--live">Ver o Arcade completo</router-link>
+        </div>
+      </div>
+    </section>
+
+    <section id="resources-preview" aria-labelledby="resources-preview-title">
+      <h2 id="resources-preview-title" class="section-title">Recursos // Biblioteca Aberta</h2>
+      <div class="hud-card">
+        <p class="card-desc" style="margin-bottom: var(--space-md);">
+          Curadoria de recursos gratuitos para quem desenvolve ou está aprendendo:
+          livros para download (como a <strong>BibliotecaDev</strong>), roadmaps de carreira,
+          ferramentas do dia a dia e cursos abertos. Útil mesmo que você não esteja me contratando. 😉
+        </p>
+        <router-link to="/recursos" class="btn-hud btn-hud--live">Explorar a biblioteca</router-link>
       </div>
     </section>
 
@@ -106,8 +116,11 @@
 </template>
 
 <script>
+import HeroTerminal from '../components/HeroTerminal.vue';
+
 export default {
   name: 'Home',
+  components: { HeroTerminal },
   data() {
     return {
       experienceData: [
@@ -236,3 +249,11 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.arcade-preview-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+</style>

--- a/src/views/MemoryGame.vue
+++ b/src/views/MemoryGame.vue
@@ -1,0 +1,402 @@
+<template>
+  <main id="main-content">
+    <div class="mm-app-bar">
+      <router-link to="/arcade" class="mm-app-back" aria-label="Voltar ao arcade">&larr; Arcade</router-link>
+      <span class="mm-app-title">Jogo da Memória</span>
+    </div>
+
+    <section id="memory-game" aria-labelledby="memory-title">
+      <h2 id="memory-title" class="section-title">Memória — Stack Edition</h2>
+
+      <div class="hud-card mm-intro" v-if="!started">
+        <p>
+          Jogo da memória com as tecnologias do meu dia a dia. Vire duas cartas por vez e
+          encontre todos os pares. O relógio começa na primeira carta virada — seu melhor
+          tempo fica salvo no navegador.
+        </p>
+      </div>
+
+      <div class="hud-card mm-panel">
+        <div class="mm-controls-row">
+          <div class="mm-control-row">
+            <label for="mm-difficulty">Dificuldade</label>
+            <select id="mm-difficulty" v-model.number="pairCount">
+              <option :value="8">Fácil — 16 cartas</option>
+              <option :value="12">Médio — 24 cartas</option>
+              <option :value="18">Difícil — 36 cartas</option>
+            </select>
+          </div>
+          <button class="btn-hud btn-hud--live" @click="startNewGame">
+            {{ started ? 'Reiniciar' : 'Começar' }}
+          </button>
+        </div>
+
+        <template v-if="started">
+          <div class="mm-panel-divider" aria-hidden="true"></div>
+          <div class="mm-stats" aria-live="polite">
+            <span>⏱ {{ formattedTime }}</span>
+            <span>🃏 {{ moves }} jogadas</span>
+            <span>✅ {{ matchedPairs }}/{{ pairCount }} pares</span>
+            <span v-if="bestForCurrent">🏆 Recorde: {{ formatTime(bestForCurrent.time) }} · {{ bestForCurrent.moves }} jogadas</span>
+          </div>
+        </template>
+      </div>
+
+      <div v-if="started" class="hud-card mm-board-card">
+        <div class="mm-grid" :class="'mm-grid--' + pairCount" role="group" aria-label="Cartas do jogo da memória">
+          <button
+            v-for="card in cards"
+            :key="card.id"
+            type="button"
+            class="mm-card"
+            :class="{ 'mm-card--flipped': card.flipped || card.matched, 'mm-card--matched': card.matched }"
+            :disabled="card.matched || card.flipped || lockBoard || won"
+            :aria-label="card.flipped || card.matched ? card.label : 'Carta virada para baixo'"
+            @click="flipCard(card)"
+          >
+            <span class="mm-card-inner">
+              <span class="mm-card-back" aria-hidden="true">&lt;/&gt;</span>
+              <span class="mm-card-front" aria-hidden="true">
+                <span class="mm-glyph">{{ card.glyph }}</span>
+                <span class="mm-label">{{ card.label }}</span>
+              </span>
+            </span>
+          </button>
+        </div>
+
+        <div v-if="won" class="mm-victory" role="status">
+          <p class="mm-victory-title">// PARES SINCRONIZADOS //</p>
+          <p>Você fechou {{ pairCount }} pares em {{ formattedTime }} com {{ moves }} jogadas.</p>
+          <p v-if="isNewRecord" class="mm-record">Novo recorde pessoal! 🏆</p>
+          <button class="btn-hud btn-hud--live" @click="startNewGame">Jogar de novo</button>
+        </div>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script>
+const TECH_DECK = [
+  { label: 'Java', glyph: '☕' },
+  { label: 'Docker', glyph: '🐳' },
+  { label: 'PostgreSQL', glyph: '🐘' },
+  { label: 'Kafka', glyph: '📨' },
+  { label: 'AWS', glyph: '☁️' },
+  { label: 'Vue', glyph: '💚' },
+  { label: 'Python', glyph: '🐍' },
+  { label: 'Git', glyph: '🌿' },
+  { label: 'Kubernetes', glyph: '☸️' },
+  { label: 'TypeScript', glyph: '🔷' },
+  { label: 'Kotlin', glyph: '🟣' },
+  { label: 'Terminal', glyph: '💻' },
+  { label: 'API REST', glyph: '🔌' },
+  { label: 'Segurança', glyph: '🔐' },
+  { label: 'Deploy', glyph: '🚀' },
+  { label: 'Testes', glyph: '🧪' },
+  { label: 'Observab.', glyph: '📈' },
+  { label: 'Bug Fix', glyph: '🐛' },
+];
+
+const STORAGE_KEY = 'rebeca-memory-best';
+
+export default {
+  name: 'MemoryGame',
+  data() {
+    return {
+      pairCount: 8,
+      started: false,
+      cards: [],
+      flippedCards: [],
+      lockBoard: false,
+      moves: 0,
+      matchedPairs: 0,
+      seconds: 0,
+      timerId: null,
+      won: false,
+      isNewRecord: false,
+      bestScores: this.loadBestScores(),
+    };
+  },
+  computed: {
+    formattedTime() { return this.formatTime(this.seconds); },
+    bestForCurrent() { return this.bestScores[this.pairCount] || null; },
+  },
+  beforeUnmount() {
+    this.stopTimer();
+  },
+  methods: {
+    loadBestScores() {
+      try {
+        return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+      } catch (error) {
+        return {};
+      }
+    },
+    formatTime(total) {
+      const min = String(Math.floor(total / 60)).padStart(2, '0');
+      const sec = String(total % 60).padStart(2, '0');
+      return `${min}:${sec}`;
+    },
+    startNewGame() {
+      this.stopTimer();
+      const deck = TECH_DECK.slice(0, this.pairCount);
+      const doubled = deck.flatMap((item, pairIndex) => [
+        { id: pairIndex * 2, pairIndex, ...item, flipped: false, matched: false },
+        { id: pairIndex * 2 + 1, pairIndex, ...item, flipped: false, matched: false },
+      ]);
+      // Fisher-Yates
+      for (let i = doubled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [doubled[i], doubled[j]] = [doubled[j], doubled[i]];
+      }
+      this.cards = doubled;
+      this.flippedCards = [];
+      this.lockBoard = false;
+      this.moves = 0;
+      this.matchedPairs = 0;
+      this.seconds = 0;
+      this.won = false;
+      this.isNewRecord = false;
+      this.started = true;
+    },
+    startTimer() {
+      if (this.timerId) return;
+      this.timerId = setInterval(() => { this.seconds++; }, 1000);
+    },
+    stopTimer() {
+      if (this.timerId) {
+        clearInterval(this.timerId);
+        this.timerId = null;
+      }
+    },
+    flipCard(card) {
+      this.startTimer();
+      card.flipped = true;
+      this.flippedCards.push(card);
+      if (this.flippedCards.length < 2) return;
+
+      this.moves++;
+      const [first, second] = this.flippedCards;
+      if (first.pairIndex === second.pairIndex) {
+        first.matched = true;
+        second.matched = true;
+        this.flippedCards = [];
+        this.matchedPairs++;
+        if (this.matchedPairs === this.pairCount) this.finishGame();
+      } else {
+        this.lockBoard = true;
+        setTimeout(() => {
+          first.flipped = false;
+          second.flipped = false;
+          this.flippedCards = [];
+          this.lockBoard = false;
+        }, 900);
+      }
+    },
+    finishGame() {
+      this.stopTimer();
+      this.won = true;
+      const best = this.bestScores[this.pairCount];
+      if (!best || this.seconds < best.time || (this.seconds === best.time && this.moves < best.moves)) {
+        this.isNewRecord = true;
+        this.bestScores = { ...this.bestScores, [this.pairCount]: { time: this.seconds, moves: this.moves } };
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(this.bestScores));
+        } catch (error) {
+          // localStorage indisponível (modo privado): recorde só vale na sessão
+        }
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.mm-app-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 12px var(--space-lg);
+  margin: 0 calc(-1 * var(--space-lg)) var(--space-md);
+  background: var(--bg-surface);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--cyan-border);
+}
+.mm-app-back {
+  color: var(--cyan-core);
+  text-decoration: none;
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.mm-app-title {
+  font-family: var(--font-ui);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-main);
+  font-size: 0.95rem;
+}
+
+#memory-title {
+  font-size: 1.3rem;
+  margin-bottom: 10px;
+}
+.mm-intro { margin-bottom: var(--space-md); }
+.mm-intro p { color: var(--text-main); }
+
+.mm-panel {
+  padding: 12px var(--space-lg);
+  gap: 6px;
+  margin-bottom: var(--space-md);
+}
+.mm-controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-md) var(--space-lg);
+}
+.mm-control-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.mm-control-row label {
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  color: var(--cyan-core);
+  text-transform: uppercase;
+}
+.mm-control-row select {
+  background: var(--bg-surface);
+  color: var(--text-main);
+  border: 1px solid var(--cyan-border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--font-read);
+  font-size: 0.9rem;
+}
+.mm-panel-divider {
+  border-top: 1px dashed var(--cyan-dim);
+  margin: var(--space-sm) 0;
+}
+.mm-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  font-family: var(--font-code);
+  font-size: 0.85rem;
+  color: var(--text-main);
+}
+
+.mm-board-card {
+  padding: var(--space-md);
+  align-items: center;
+  gap: var(--space-md);
+}
+.mm-grid {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+  max-width: 640px;
+}
+.mm-grid--8 { grid-template-columns: repeat(4, 1fr); }
+.mm-grid--12 { grid-template-columns: repeat(4, 1fr); }
+.mm-grid--18 { grid-template-columns: repeat(6, 1fr); }
+@media (min-width: 640px) {
+  .mm-grid--12 { grid-template-columns: repeat(6, 1fr); }
+}
+
+.mm-card {
+  aspect-ratio: 3 / 4;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  perspective: 600px;
+}
+.mm-card:disabled { cursor: default; }
+.mm-card-inner {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.4s;
+}
+.mm-card--flipped .mm-card-inner { transform: rotateY(180deg); }
+@media (prefers-reduced-motion: reduce) {
+  .mm-card-inner { transition: none; }
+}
+
+.mm-card-back,
+.mm-card-front {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  backface-visibility: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--cyan-border);
+}
+.mm-card-back {
+  background:
+    repeating-linear-gradient(45deg, var(--cyan-dim) 0 6px, transparent 6px 12px),
+    var(--bg-surface);
+  border-color: var(--cyan-core);
+  box-shadow: inset 0 0 12px var(--cyan-dim);
+  color: var(--cyan-core);
+  font-family: var(--font-code);
+  font-size: 1.2rem;
+}
+.mm-card:not(:disabled):hover .mm-card-back {
+  box-shadow: 0 0 15px var(--cyan-dim);
+  border-color: var(--cyan-core);
+}
+.mm-card-front {
+  background: var(--bg-surface);
+  transform: rotateY(180deg);
+}
+.mm-card--matched .mm-card-front {
+  border-color: var(--cyan-core);
+  box-shadow: 0 0 12px var(--cyan-dim);
+}
+.mm-glyph { font-size: clamp(1.2rem, 5vw, 2rem); }
+.mm-label {
+  font-family: var(--font-code);
+  font-size: clamp(0.5rem, 1.8vw, 0.7rem);
+  color: var(--text-muted);
+  text-align: center;
+  padding: 0 2px;
+}
+
+.mm-victory {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: 1px dashed var(--cyan-border);
+  border-radius: 8px;
+  width: 100%;
+}
+.mm-victory-title {
+  font-family: var(--font-code);
+  color: var(--cyan-core);
+  letter-spacing: 2px;
+}
+.mm-victory p { color: var(--text-main); }
+.mm-record { color: var(--cyan-core); font-weight: 600; }
+
+@media (max-width: 768px) {
+  .mm-app-bar { margin: 0 0 var(--space-md); }
+  .mm-grid { gap: 6px; }
+}
+</style>

--- a/src/views/Resources.vue
+++ b/src/views/Resources.vue
@@ -1,0 +1,292 @@
+<template>
+  <main id="main-content">
+    <section id="resources" aria-labelledby="resources-title">
+      <h2 id="resources-title" class="section-title">Recursos // Biblioteca Aberta</h2>
+
+      <div class="hud-card res-intro">
+        <p>
+          Uma curadoria de <strong>recursos gratuitos e de qualidade</strong> que eu uso e recomendo:
+          livros, roadmaps, ferramentas e cursos. Tudo aberto, sem cadastro pago — salve esta página
+          e volte sempre que precisar. Contribuições e sugestões são bem-vindas via
+          <a href="https://github.com/rebecanonato89/rebecanonato89/issues" target="_blank" rel="noopener noreferrer">issues no GitHub</a>.
+        </p>
+      </div>
+
+      <section
+        v-for="category in categories"
+        :key="category.title"
+        class="res-category"
+        :aria-labelledby="'res-' + category.id"
+      >
+        <h3 :id="'res-' + category.id" class="res-category-title">
+          <span aria-hidden="true">{{ category.icon }}</span> {{ category.title }}
+        </h3>
+        <div class="res-grid">
+          <a
+            v-for="item in category.items"
+            :key="item.name"
+            :href="item.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="hud-card res-card"
+            :class="{ 'res-card--featured': item.featured }"
+          >
+            <div class="res-card-top">
+              <span class="res-name">{{ item.name }}</span>
+              <span v-if="item.featured" class="res-badge">Destaque</span>
+              <span v-else-if="item.lang" class="res-lang">{{ item.lang }}</span>
+            </div>
+            <p class="res-desc">{{ item.description }}</p>
+            <span class="res-url" aria-hidden="true">{{ shortUrl(item.url) }} ↗</span>
+          </a>
+        </div>
+      </section>
+    </section>
+  </main>
+</template>
+
+<script>
+export default {
+  name: 'Resources',
+  data() {
+    return {
+      categories: [
+        {
+          id: 'books',
+          icon: '📚',
+          title: 'Livros e Bibliotecas de Download',
+          items: [
+            {
+              name: 'BibliotecaDev',
+              url: 'https://github.com/KAYOKG/BibliotecaDev',
+              description: 'Acervo enorme de livros de programação para download: Java, Python, JavaScript, arquitetura, bancos de dados e muito mais.',
+              featured: true,
+            },
+            {
+              name: 'Free Programming Books (PT-BR)',
+              url: 'https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-pt_BR.md',
+              description: 'A maior lista do mundo de livros de programação gratuitos, na seção em português. Mantida pela Free Ebook Foundation.',
+              lang: 'PT-BR',
+            },
+            {
+              name: 'Goalkicker Books',
+              url: 'https://books.goalkicker.com/',
+              description: 'Dezenas de livros em PDF compilados da documentação do Stack Overflow: Java, SQL, Python, Git, Kotlin e mais.',
+              lang: 'EN',
+            },
+            {
+              name: 'Papers We Love',
+              url: 'https://github.com/papers-we-love/papers-we-love',
+              description: 'Coleção de papers acadêmicos clássicos de ciência da computação — sistemas distribuídos, bancos de dados, linguagens.',
+              lang: 'EN',
+            },
+          ],
+        },
+        {
+          id: 'roadmaps',
+          icon: '🗺️',
+          title: 'Roadmaps e Guias de Estudo',
+          items: [
+            {
+              name: 'roadmap.sh',
+              url: 'https://roadmap.sh',
+              description: 'Roadmaps visuais e interativos de carreira: backend, frontend, DevOps, IA, arquitetura de software e mais.',
+              lang: 'EN',
+            },
+            {
+              name: 'System Design Primer',
+              url: 'https://github.com/donnemartin/system-design-primer',
+              description: 'O guia definitivo (e gratuito) de system design: escalabilidade, cache, filas, bancos — essencial para entrevistas sênior.',
+              lang: 'EN',
+            },
+            {
+              name: 'Refactoring Guru',
+              url: 'https://refactoring.guru/pt-br',
+              description: 'Design patterns e refatoração explicados com ilustrações excelentes, totalmente traduzido para português.',
+              lang: 'PT-BR',
+            },
+            {
+              name: 'Build Your Own X',
+              url: 'https://github.com/codecrafters-io/build-your-own-x',
+              description: 'Aprenda construindo: tutoriais para criar seu próprio banco de dados, docker, git, compilador, blockchain…',
+              lang: 'EN',
+            },
+            {
+              name: 'Tech Interview Handbook',
+              url: 'https://www.techinterviewhandbook.org/',
+              description: 'Preparação completa e gratuita para entrevistas técnicas: algoritmos, behavioral e negociação de salário.',
+              lang: 'EN',
+            },
+          ],
+        },
+        {
+          id: 'tools',
+          icon: '🛠️',
+          title: 'Ferramentas do Dia a Dia',
+          items: [
+            {
+              name: 'regex101',
+              url: 'https://regex101.com',
+              description: 'Teste e depure expressões regulares com explicação passo a passo de cada token.',
+              lang: 'EN',
+            },
+            {
+              name: 'Crontab Guru',
+              url: 'https://crontab.guru',
+              description: 'Traduz expressões cron para linguagem humana. Nunca mais erre um agendamento.',
+              lang: 'EN',
+            },
+            {
+              name: 'JWT.io',
+              url: 'https://jwt.io',
+              description: 'Decodifique e inspecione tokens JWT direto no navegador — indispensável para depurar autenticação.',
+              lang: 'EN',
+            },
+            {
+              name: 'Excalidraw',
+              url: 'https://excalidraw.com',
+              description: 'Quadro branco virtual com estética de desenho à mão. Perfeito para diagramas de arquitetura.',
+              lang: 'EN',
+            },
+            {
+              name: 'JSON Crack',
+              url: 'https://jsoncrack.com',
+              description: 'Visualize JSONs gigantes como grafos navegáveis. Salva vidas ao depurar payloads complexos.',
+              lang: 'EN',
+            },
+            {
+              name: 'DevDocs',
+              url: 'https://devdocs.io',
+              description: 'Documentação de dezenas de linguagens e frameworks unificada, com busca rápida e modo offline.',
+              lang: 'EN',
+            },
+          ],
+        },
+        {
+          id: 'courses',
+          icon: '🎓',
+          title: 'Cursos e Certificações Gratuitas',
+          items: [
+            {
+              name: 'Curso em Vídeo',
+              url: 'https://www.cursoemvideo.com',
+              description: 'Cursos gratuitos do Gustavo Guanabara: lógica, Python, Java, HTML/CSS e Git — a melhor porta de entrada em português.',
+              lang: 'PT-BR',
+            },
+            {
+              name: 'freeCodeCamp',
+              url: 'https://www.freecodecamp.org',
+              description: 'Certificações gratuitas com projetos práticos: web, JavaScript, bancos relacionais, machine learning.',
+              lang: 'EN',
+            },
+            {
+              name: 'CS50 — Harvard',
+              url: 'https://cs50.harvard.edu/x/',
+              description: 'O curso introdutório de ciência da computação mais famoso do mundo, gratuito e com certificado opcional.',
+              lang: 'EN',
+            },
+            {
+              name: 'AWS Skill Builder',
+              url: 'https://skillbuilder.aws',
+              description: 'Centenas de cursos oficiais gratuitos da AWS — o caminho para as certificações Cloud Practitioner e além.',
+              lang: 'EN',
+            },
+            {
+              name: 'Full Stack Open',
+              url: 'https://fullstackopen.com/pt/',
+              description: 'Curso universitário completo (Univ. de Helsinque) de desenvolvimento web moderno: React, Node, GraphQL, TypeScript.',
+              lang: 'PT-BR',
+            },
+          ],
+        },
+      ],
+    };
+  },
+  methods: {
+    shortUrl(url) {
+      return url.replace(/^https?:\/\//, '').replace(/\/$/, '').split('/').slice(0, 2).join('/');
+    },
+  },
+};
+</script>
+
+<style scoped>
+.res-intro { margin-bottom: var(--space-lg); }
+.res-intro p { color: var(--text-main); }
+.res-intro a { color: var(--cyan-core); }
+
+.res-category { margin-bottom: var(--space-xl); }
+.res-category-title {
+  font-family: var(--font-ui);
+  font-size: 1.5rem;
+  color: var(--text-main);
+  margin-bottom: var(--space-md);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.res-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-md);
+}
+@media (min-width: 700px) {
+  .res-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1100px) {
+  .res-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.res-card {
+  text-decoration: none;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+}
+.res-card--featured {
+  border-color: var(--cyan-core);
+  box-shadow: 0 0 18px var(--cyan-dim);
+}
+.res-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+.res-name {
+  font-family: var(--font-ui);
+  font-size: 1.2rem;
+  color: var(--text-main);
+}
+.res-badge {
+  font-family: var(--font-code);
+  font-size: 0.7rem;
+  background: var(--cyan-core);
+  color: var(--bg-base);
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.res-lang {
+  font-family: var(--font-code);
+  font-size: 0.7rem;
+  color: var(--cyan-core);
+  border: 1px dashed var(--cyan-border);
+  padding: 2px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.res-desc {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  flex-grow: 1;
+}
+.res-card:hover .res-desc { color: var(--text-main); }
+.res-url {
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  color: var(--cyan-core);
+}
+</style>


### PR DESCRIPTION
## O que mudou

### 🕹️ Arcade (`/arcade`)
Novo hub reunindo os três jogos, todos implementados do zero (regras, IA e interface):

- **Damas Brasileiras** (`/damas`) — regras oficiais: captura obrigatória (inclusive para trás pelas pedras), **lei da maioria**, **dama voadora** e capturas em cadeia. IA com **minimax + poda alfa-beta** em 3 níveis (aleatória, profundidade 4, aprofundamento iterativo com orçamento de ~900ms). Lógica pura em `src/checkers/` separada da view.
- **Jogo da Memória** (`/memoria`) — tema de tecnologias, 3 dificuldades (16/24/36 cartas), flip 3D em CSS, cronômetro, contador de jogadas e recorde salvo em `localStorage`.
- **Go** — jogo existente integrado ao hub, com barra de volta apontando para o Arcade.

### 📚 Biblioteca de Recursos (`/recursos`)
Curadoria de recursos gratuitos para o site ser útil a qualquer dev, não só a recrutadores: **BibliotecaDev** (destaque), free-programming-books PT-BR, Goalkicker, Papers We Love, roadmap.sh, System Design Primer, Refactoring Guru, regex101, Crontab Guru, JWT.io, Excalidraw, JSON Crack, DevDocs, Curso em Vídeo, freeCodeCamp, CS50, AWS Skill Builder e Full Stack Open.

### 💻 Terminal interativo na Home
Um terminal fake no topo da página como navegação alternativa: `help`, `sobre`, `projetos`, `arcade`, `recursos`, `go`, `damas`, `memoria`, `whoami`, `github`, `linkedin`, `clear` (e um easter egg de `sudo`).

### 🧭 Fluxo e navegação
- Header global com **Arcade** e **Recursos** em todas as páginas.
- Home ganhou seções de preview do Arcade e da Biblioteca antes do contato.
- Modo app (tela cheia, sem header/footer) estendido do Go para todas as rotas de jogo.
- README atualizado com a seção *Arcade & Biblioteca Aberta*.

## Como foi verificado

- Lógica de Damas testada em Node: tabuleiro inicial (7 lances), captura dupla com lei da maioria + promoção, dama voadora com múltiplos pousos, partida completa IA vs IA sem crash, nível 3 respondendo dentro do orçamento de tempo.
- `vite build` sem erros.
- Todas as rotas exercitadas em Chromium headless (Playwright): terminal respondendo comandos, partida de Damas com lance humano + resposta da IA, cartas da memória virando com animação, 20 cards de recursos com o link da BibliotecaDev presente. Sem erros de JS no console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kaw2wQzezVP2PyJ4wrEF2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kaw2wQzezVP2PyJ4wrEF2F)_