### PR TITLE
Novo tema Índigo/Violeta + Âmbar, menu fixo e visual mais moderno

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,8 @@
         <span>SYS.INIT // SOFTWARE_ENGINEER_SENIOR</span>
       </div>
       <nav aria-label="Navegação Principal">
-        <ul v-if="$route.path === '/'">
+        <ul>
+          <li v-if="$route.path !== '/'"><router-link to="/" class="nav-back">&larr; Portfólio</router-link></li>
           <li><a href="#about" @click.prevent="scrollToId('about')">Identidade</a></li>
           <li><a href="#experience" @click.prevent="scrollToId('experience')">Log Execução</a></li>
           <li><a href="#projects" @click.prevent="scrollToId('projects')">Deployments</a></li>
@@ -55,12 +56,6 @@
           <li><router-link to="/recursos" class="nav-highlight">Recursos</router-link></li>
           <li><router-link to="/servicos" class="nav-highlight">Serviços</router-link></li>
           <li><a href="#contact" @click.prevent="scrollToId('contact')">Uplink</a></li>
-        </ul>
-        <ul v-else>
-          <li><router-link to="/">&larr; Portfólio</router-link></li>
-          <li><router-link to="/arcade">Arcade</router-link></li>
-          <li><router-link to="/recursos">Recursos</router-link></li>
-          <li><router-link to="/servicos">Serviços</router-link></li>
         </ul>
       </nav>
     </header>
@@ -134,6 +129,16 @@ export default {
       this.applyBodyClass();
     },
     scrollToId(id) {
+      // Os itens Identidade/Log Execução/Deployments/Uplink são âncoras da Home;
+      // como o menu agora fica fixo em todas as páginas, primeiro voltamos pra Home
+      // (se necessário) antes de rolar até a seção.
+      if (this.$route.path !== '/') {
+        this.$router.push('/').then(() => this.$nextTick(() => this.doScroll(id)));
+      } else {
+        this.doScroll(id);
+      }
+    },
+    doScroll(id) {
       const el = document.getElementById(id);
       if (el) el.scrollIntoView({ behavior: 'smooth' });
     },
@@ -164,6 +169,7 @@ export default {
   --text-main: #e8e6f5;
   --text-muted: #9691b5;
   --scrim-overlay: rgba(6, 6, 14, 0.88);
+  --card-shadow: rgba(0, 0, 0, 0.35);
 
   --font-ui: 'Space Grotesk', sans-serif;
   --font-read: 'Inter', sans-serif;
@@ -172,7 +178,11 @@ export default {
   --space-sm: 0.5rem;
   --space-md: 1rem;
   --space-lg: 2rem;
-  --space-xl: 4rem;
+  --space-xl: clamp(3rem, 6vw, 5.5rem);
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 18px;
 }
 
 /* =========================================
@@ -188,6 +198,7 @@ export default {
   --text-main: #201c33;
   --text-muted: #5b5570;
   --scrim-overlay: rgba(235, 232, 245, 0.88);
+  --card-shadow: rgba(76, 60, 130, 0.1);
 }
 
 /* =========================================
@@ -203,6 +214,7 @@ export default {
   --text-main: #FFFFFF;
   --text-muted: #FFFFFF;
   --scrim-overlay: #000000;
+  --card-shadow: transparent;
 }
 
 /* RESET */
@@ -316,7 +328,8 @@ body {
   display: flex; gap: 8px; align-items: center;
   z-index: 1000; background: var(--bg-surface);
   padding: 8px; border: 1px solid var(--accent-border);
-  border-radius: 8px; backdrop-filter: blur(10px);
+  border-radius: var(--radius-md); backdrop-filter: blur(10px);
+  box-shadow: 0 4px 16px var(--card-shadow);
   transition: background 0.4s, border-color 0.4s;
 }
 
@@ -327,7 +340,7 @@ body {
 
 .a11y-btn {
   background: transparent; color: var(--text-main);
-  border: 1px solid var(--accent-border); border-radius: 4px;
+  border: 1px solid var(--accent-border); border-radius: var(--radius-sm);
   padding: 6px 12px; font-family: var(--font-code);
   font-size: 1rem; font-weight: bold; cursor: pointer;
   transition: background 0.25s cubic-bezier(.2,.8,.2,1), color 0.25s cubic-bezier(.2,.8,.2,1),
@@ -363,25 +376,48 @@ header {
 
 .brand h1 { font-family: var(--font-ui); font-size: 2rem; color: var(--text-main); text-transform: uppercase; letter-spacing: 2px; text-shadow: 0 0 10px var(--accent-dim); }
 .brand span { font-family: var(--font-code); font-size: 0.8rem; color: var(--accent-core); }
-nav ul { list-style: none; display: flex; gap: var(--space-lg); }
-nav a { color: var(--text-muted); text-decoration: none; font-family: var(--font-ui); font-size: 1.1rem; text-transform: uppercase; transition: 0.3s; }
+nav ul { list-style: none; display: flex; flex-wrap: wrap; align-items: center; gap: 0.6rem 1.1rem; justify-content: flex-end; }
+nav a {
+  color: var(--text-muted); text-decoration: none; font-family: var(--font-ui); font-size: 0.95rem;
+  text-transform: uppercase; white-space: nowrap; letter-spacing: 0.5px;
+  transition: color 0.3s, text-shadow 0.3s, border-color 0.3s, background 0.3s;
+}
 nav a:hover { color: var(--accent-core); text-shadow: 0 0 8px var(--accent-dim); }
-nav a.nav-highlight { color: var(--accent-core); }
+
+/* Arcade/Recursos/Serviços são páginas separadas (não âncoras da Home), por isso
+   ganham uma borda fina pra se diferenciar dos demais itens sem depender só de cor. */
+nav a.nav-highlight {
+  border: 1px solid var(--accent-border); border-radius: var(--radius-sm); padding: 3px 9px;
+}
+nav a.nav-highlight:hover { border-color: var(--accent-core); }
+
+/* Botão de voltar ao portfólio: precisa ficar bem visível nas páginas internas. */
+nav a.nav-back {
+  color: var(--accent-core); background: var(--accent-dim); border: 1px solid var(--accent-border);
+  border-radius: var(--radius-sm); padding: 3px 10px; font-weight: 600;
+}
+nav a.nav-back:hover { background: var(--accent-core); color: var(--bg-base); border-color: var(--accent-core); }
 
 section { margin-bottom: var(--space-xl); }
 .section-title {
-  font-family: var(--font-ui); font-size: 2.2rem; color: var(--text-main); margin-bottom: var(--space-lg);
+  font-family: var(--font-ui); font-size: 2.2rem; color: var(--text-main);
+  margin-bottom: var(--space-lg); padding-bottom: var(--space-md);
   display: flex; align-items: center; gap: var(--space-md);
+  border-bottom: 1px solid var(--accent-border);
 }
-.section-title::before { content: ''; display: block; width: 12px; height: 12px; background: var(--accent-core); box-shadow: 0 0 10px var(--accent-dim); }
+.section-title::before {
+  content: ''; display: block; width: 10px; height: 10px; border-radius: 50%;
+  background: var(--accent-core); box-shadow: 0 0 10px var(--accent-dim); flex-shrink: 0;
+}
 
 .hud-card {
   background: var(--bg-surface);
   border: 1px solid var(--accent-border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: var(--space-lg);
   display: flex;
   flex-direction: column;
+  box-shadow: 0 4px 20px var(--card-shadow);
   transition: transform 0.35s cubic-bezier(.2,.8,.2,1), border-color 0.35s cubic-bezier(.2,.8,.2,1),
     box-shadow 0.35s cubic-bezier(.2,.8,.2,1), background 0.4s ease;
   backdrop-filter: blur(10px);
@@ -398,7 +434,7 @@ section { margin-bottom: var(--space-xl); }
 
 .high-contrast-mode .hud-card { border-width: 2px; box-shadow: none !important; }
 
-.card-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-md); border-bottom: 1px dashed var(--accent-dim); padding-bottom: var(--space-sm); }
+.card-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-md); border-bottom: 1px solid var(--accent-dim); padding-bottom: var(--space-sm); }
 .card-title { font-family: var(--font-ui); font-size: 1.6rem; color: var(--text-main); margin-bottom: 0; }
 .card-period { font-family: var(--font-code); font-size: 0.85rem; color: var(--accent-core); }
 
@@ -408,11 +444,11 @@ section { margin-bottom: var(--space-xl); }
 .project-grid { display: grid; grid-template-columns: 1fr; gap: var(--space-lg); }
 
 .tech-list { list-style: none; display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-bottom: var(--space-lg); }
-.tech-tag { font-family: var(--font-code); font-size: 0.75rem; color: var(--accent-core); background: var(--accent-dim); border: 1px dashed var(--accent-border); padding: 4px 8px; border-radius: 4px; }
+.tech-tag { font-family: var(--font-code); font-size: 0.75rem; color: var(--accent-core); background: var(--accent-dim); border: 1px solid var(--accent-border); padding: 4px 10px; border-radius: var(--radius-sm); }
 
 .btn-hud {
   display: inline-flex; align-items: center; gap: 8px; background: var(--accent-dim); color: var(--accent-core);
-  border: 1px solid var(--accent-border); padding: 8px 16px; font-family: var(--font-ui); font-size: 1.1rem;
+  border: 1px solid var(--accent-border); border-radius: var(--radius-md); padding: 8px 18px; font-family: var(--font-ui); font-size: 1.1rem;
   text-decoration: none; text-transform: uppercase; align-self: flex-start;
   transition: background 0.3s cubic-bezier(.2,.8,.2,1), color 0.3s cubic-bezier(.2,.8,.2,1),
     box-shadow 0.3s cubic-bezier(.2,.8,.2,1), transform 0.3s cubic-bezier(.2,.8,.2,1);

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,20 @@
 <template>
   <div class="container" :class="{ 'high-contrast-mode': isHighContrast, 'light-mode': isLightMode, 'app-mode': isGameRoute }">
+    <div class="bg-icons" aria-hidden="true">
+      <svg class="bg-icon bg-icon-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="8 4 2 12 8 20"></polyline><polyline points="16 4 22 12 16 20"></polyline></svg>
+      <svg class="bg-icon bg-icon-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 3H6a2 2 0 0 0-2 2v2a2 2 0 0 1-2 2 2 2 0 0 1 2 2v2a2 2 0 0 0 2 2h2"></path><path d="M16 3h2a2 2 0 0 1 2 2v2a2 2 0 0 0 2 2 2 2 0 0 0-2 2v2a2 2 0 0 1-2 2h-2"></path></svg>
+      <svg class="bg-icon bg-icon-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"></path></svg>
+      <svg class="bg-icon bg-icon-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><ellipse cx="12" cy="5" rx="8" ry="3"></ellipse><path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5"></path><path d="M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"></path></svg>
+      <svg class="bg-icon bg-icon-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="6" y1="3" x2="6" y2="15"></line><circle cx="18" cy="6" r="3"></circle><circle cx="6" cy="18" r="3"></circle><path d="M18 9a9 9 0 0 1-9 9"></path></svg>
+      <svg class="bg-icon bg-icon-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="4" width="20" height="16" rx="2"></rect><polyline points="6 9 10 12 6 15"></polyline><line x1="12" y1="15" x2="16" y2="15"></line></svg>
+      <svg class="bg-icon bg-icon-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="4" width="20" height="5" rx="1"></rect><rect x="2" y="15" width="20" height="5" rx="1"></rect><line x1="6" y1="6.5" x2="6.01" y2="6.5"></line><line x1="6" y1="17.5" x2="6.01" y2="17.5"></line></svg>
+      <svg class="bg-icon bg-icon-8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5 13a10 10 0 0 1 14 0"></path><path d="M8.5 16.5a5 5 0 0 1 7 0"></path><line x1="12" y1="20" x2="12.01" y2="20"></line></svg>
+      <svg class="bg-icon bg-icon-9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="4" y="4" width="7" height="7" rx="1"></rect><rect x="13" y="13" width="7" height="7" rx="1"></rect><rect x="4" y="13" width="7" height="7" rx="1"></rect></svg>
+      <svg class="bg-icon bg-icon-10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="6" y="6" width="12" height="12" rx="1"></rect><line x1="6" y1="1" x2="6" y2="4"></line><line x1="12" y1="1" x2="12" y2="4"></line><line x1="18" y1="1" x2="18" y2="4"></line><line x1="6" y1="20" x2="6" y2="23"></line><line x1="12" y1="20" x2="12" y2="23"></line><line x1="18" y1="20" x2="18" y2="23"></line><line x1="1" y1="6" x2="4" y2="6"></line><line x1="1" y1="12" x2="4" y2="12"></line><line x1="1" y1="18" x2="4" y2="18"></line><line x1="20" y1="6" x2="23" y2="6"></line><line x1="20" y1="12" x2="23" y2="12"></line><line x1="20" y1="18" x2="23" y2="18"></line></svg>
+      <svg class="bg-icon bg-icon-11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+      <svg class="bg-icon bg-icon-12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
+    </div>
+
     <a href="#main-content" class="skip-link" @click.prevent="skipToMain">Pular para o conteúdo principal</a>
 
     <aside class="a11y-toolbar" aria-label="Ferramentas de acessibilidade e tema">
@@ -95,9 +110,9 @@ export default {
       if (this.isHighContrast) {
         document.body.style.backgroundColor = '#000000';
       } else if (this.isLightMode) {
-        document.body.style.backgroundColor = '#f4f7fb';
+        document.body.style.backgroundColor = '#f7f6fb';
       } else {
-        document.body.style.backgroundColor = '#030509';
+        document.body.style.backgroundColor = '#0b0d17';
       }
     },
     changeFontSize(step) {
@@ -134,24 +149,26 @@ export default {
 </script>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Rajdhani:wght@500;600;700&family=Fira+Code:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 /* =========================================
-   VARIÁVEIS PADRÃO (DARK MODE / SCI-FI)
+   VARIÁVEIS PADRÃO (DARK MODE / ÍNDIGO+ÂMBAR)
    ========================================= */
 :root {
-  --bg-base: #030509;
-  --bg-surface: rgba(10, 15, 25, 0.7);
-  --cyan-core: #00e5ff;
-  --cyan-dim: rgba(0, 229, 255, 0.15);
-  --cyan-border: rgba(0, 229, 255, 0.3);
-  --text-main: #e2e8f0;
-  --text-muted: #8892b0;
-  
-  --font-ui: 'Rajdhani', sans-serif;
+  --bg-base: #0b0d17;
+  --bg-surface: rgba(20, 18, 38, 0.7);
+  --accent-core: #8b5cf6;
+  --accent-dim: rgba(139, 92, 246, 0.15);
+  --accent-border: rgba(139, 92, 246, 0.35);
+  --accent-warm: #f5a524;
+  --text-main: #e8e6f5;
+  --text-muted: #9691b5;
+  --scrim-overlay: rgba(6, 6, 14, 0.88);
+
+  --font-ui: 'Space Grotesk', sans-serif;
   --font-read: 'Inter', sans-serif;
-  --font-code: 'Fira Code', monospace;
-  
+  --font-code: 'JetBrains Mono', monospace;
+
   --space-sm: 0.5rem;
   --space-md: 1rem;
   --space-lg: 2rem;
@@ -162,13 +179,15 @@ export default {
    VARIÁVEIS MODO CLARO (LIGHT MODE)
    ========================================= */
 .light-mode {
-  --bg-base: #f4f7fb;
+  --bg-base: #f7f6fb;
   --bg-surface: rgba(255, 255, 255, 0.85);
-  --cyan-core: #0066cc; /* Azul Elétrico mais escuro para contraste */
-  --cyan-dim: rgba(0, 102, 204, 0.1);
-  --cyan-border: rgba(0, 102, 204, 0.3);
-  --text-main: #1a202c;
-  --text-muted: #4a5568;
+  --accent-core: #6d28d9; /* Violeta mais escuro para contraste em fundo claro */
+  --accent-dim: rgba(109, 40, 217, 0.08);
+  --accent-border: rgba(109, 40, 217, 0.25);
+  --accent-warm: #b8770a;
+  --text-main: #201c33;
+  --text-muted: #5b5570;
+  --scrim-overlay: rgba(235, 232, 245, 0.88);
 }
 
 /* =========================================
@@ -177,11 +196,13 @@ export default {
 .high-contrast-mode {
   --bg-base: #000000;
   --bg-surface: #000000;
-  --cyan-core: #FFFF00; /* Amarelo puro */
-  --cyan-dim: transparent;
-  --cyan-border: #FFFF00;
+  --accent-core: #FFFF00; /* Amarelo puro */
+  --accent-dim: transparent;
+  --accent-border: #FFFF00;
+  --accent-warm: #FFFF00;
   --text-main: #FFFFFF;
   --text-muted: #FFFFFF;
+  --scrim-overlay: #000000;
 }
 
 /* RESET */
@@ -196,19 +217,57 @@ body {
   transition: background-color 0.4s ease, color 0.4s ease;
 }
 
-/* O grid de fundo precisa ser gerenciado pelo wrapper para respeitar os temas */
 .container {
+  position: relative;
   min-height: 100vh;
   background-color: var(--bg-base);
-  background-image: 
-    linear-gradient(var(--cyan-dim) 1px, transparent 1px),
-    linear-gradient(90deg, var(--cyan-dim) 1px, transparent 1px);
-  background-size: 40px 40px;
-  background-attachment: fixed;
   transition: background-color 0.4s ease, max-width 0.3s ease;
   padding: 0 var(--space-lg);
   max-width: 1000px;
   margin: 0 auto;
+}
+
+/* =========================================
+   ÍCONES DE TI FLUTUANDO NO FUNDO
+   ========================================= */
+.bg-icons {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+  pointer-events: none;
+  color: var(--accent-core);
+}
+.bg-icon {
+  position: absolute;
+  fill: none;
+  opacity: 0.09;
+  animation: drift-float 26s ease-in-out infinite alternate;
+}
+.light-mode .bg-icon { opacity: 0.12; }
+.high-contrast-mode .bg-icons { display: none; }
+
+.bg-icon-1  { top: 8%;  left: 6%;   width: 56px; animation-duration: 24s; }
+.bg-icon-2  { top: 18%; right: 10%; width: 44px; animation-duration: 30s; animation-delay: -4s; }
+.bg-icon-3  { top: 4%;  right: 30%; width: 64px; animation-duration: 34s; animation-delay: -12s; }
+.bg-icon-4  { top: 38%; left: 16%;  width: 48px; animation-duration: 22s; animation-delay: -8s; }
+.bg-icon-5  { top: 62%; left: 4%;   width: 52px; animation-duration: 28s; animation-delay: -18s; }
+.bg-icon-6  { top: 72%; right: 8%;  width: 60px; animation-duration: 32s; animation-delay: -6s; }
+.bg-icon-7  { top: 46%; right: 22%; width: 40px; animation-duration: 20s; animation-delay: -14s; }
+.bg-icon-8  { top: 86%; left: 30%;  width: 36px; animation-duration: 26s; animation-delay: -10s; }
+.bg-icon-9  { top: 28%; left: 44%;  width: 32px; animation-duration: 24s; animation-delay: -20s; }
+.bg-icon-10 { top: 92%; right: 38%; width: 46px; animation-duration: 30s; animation-delay: -2s; }
+.bg-icon-11 { top: 14%; left: 36%;  width: 42px; animation-duration: 34s; animation-delay: -16s; }
+.bg-icon-12 { top: 56%; right: 46%; width: 38px; animation-duration: 22s; animation-delay: -9s; }
+
+@keyframes drift-float {
+  0%   { transform: translate(0, 0) rotate(0deg); }
+  50%  { transform: translate(12px, -16px) rotate(4deg); }
+  100% { transform: translate(-10px, 10px) rotate(-3deg); }
+}
+
+@media (max-width: 768px) {
+  .bg-icon-9, .bg-icon-10, .bg-icon-11, .bg-icon-12 { display: none; }
 }
 
 /* Em telas grandes o conteúdo cresce em vez de ficar preso numa coluna estreita */
@@ -230,15 +289,12 @@ body {
   display: none;
 }
 
-/* Desliga fundo no alto contraste */
-.high-contrast-mode.container { background-image: none !important; }
-
 /* =========================================
    ACESSBILIDADE & BARRA HUD
    ========================================= */
 .skip-link {
   position: absolute; top: -100px; left: 0;
-  background: var(--cyan-core); color: #000;
+  background: var(--accent-core); color: #000;
   padding: var(--space-md); z-index: 9999;
   font-family: var(--font-ui); font-weight: bold; text-transform: uppercase;
   transition: top 0.2s; text-decoration: none;
@@ -251,33 +307,37 @@ body {
 }
 
 *:focus-visible {
-  outline: 2px dashed var(--cyan-core); outline-offset: 4px;
-  box-shadow: 0 0 15px var(--cyan-dim); border-radius: 4px;
+  outline: 2px dashed var(--accent-core); outline-offset: 4px;
+  box-shadow: 0 0 15px var(--accent-dim); border-radius: 4px;
 }
 
 .a11y-toolbar {
   position: fixed; top: 20px; right: 20px;
   display: flex; gap: 8px; align-items: center;
   z-index: 1000; background: var(--bg-surface);
-  padding: 8px; border: 1px solid var(--cyan-border);
+  padding: 8px; border: 1px solid var(--accent-border);
   border-radius: 8px; backdrop-filter: blur(10px);
   transition: background 0.4s, border-color 0.4s;
 }
 
 .a11y-divider {
-  width: 1px; height: 24px; background-color: var(--cyan-border);
+  width: 1px; height: 24px; background-color: var(--accent-border);
   margin: 0 4px;
 }
 
 .a11y-btn {
   background: transparent; color: var(--text-main);
-  border: 1px solid var(--cyan-border); border-radius: 4px;
+  border: 1px solid var(--accent-border); border-radius: 4px;
   padding: 6px 12px; font-family: var(--font-code);
   font-size: 1rem; font-weight: bold; cursor: pointer;
-  transition: all 0.2s; display: flex; align-items: center; justify-content: center;
+  transition: background 0.25s cubic-bezier(.2,.8,.2,1), color 0.25s cubic-bezier(.2,.8,.2,1),
+    box-shadow 0.25s cubic-bezier(.2,.8,.2,1), transform 0.25s cubic-bezier(.2,.8,.2,1);
+  display: flex; align-items: center; justify-content: center;
 }
 .a11y-btn:hover, .a11y-btn:focus-visible {
-  background: var(--cyan-core); color: var(--bg-base);
+  background: var(--accent-core); color: var(--bg-base);
+  box-shadow: 0 0 12px var(--accent-dim);
+  transform: translateY(-1px);
 }
 .a11y-btn svg { width: 16px; height: 16px; }
 .theme-btn { padding: 6px 8px; }
@@ -287,7 +347,7 @@ body {
    ========================================= */
 header {
   padding: var(--space-lg) 0; display: flex; justify-content: space-between; align-items: center;
-  border-bottom: 1px solid var(--cyan-border); margin-bottom: var(--space-xl);
+  border-bottom: 1px solid var(--accent-border); margin-bottom: var(--space-xl);
   background: var(--bg-surface);
   position: sticky; top: 0; z-index: 100; backdrop-filter: blur(8px);
   transition: background 0.4s, border-color 0.4s;
@@ -297,49 +357,50 @@ header {
 }
 
 /* Gradiente na borda superior apenas no Dark Mode (Fica feio no claro) */
-body:not(.light-mode):not(.high-contrast-mode) header {
-  background: linear-gradient(180deg, rgba(3,5,9,0.95) 0%, rgba(3,5,9,0) 100%);
+.container:not(.light-mode):not(.high-contrast-mode) header {
+  background: linear-gradient(180deg, rgba(11,13,23,0.95) 0%, rgba(11,13,23,0) 100%);
 }
 
-.brand h1 { font-family: var(--font-ui); font-size: 2rem; color: var(--text-main); text-transform: uppercase; letter-spacing: 2px; text-shadow: 0 0 10px var(--cyan-dim); }
-.brand span { font-family: var(--font-code); font-size: 0.8rem; color: var(--cyan-core); }
+.brand h1 { font-family: var(--font-ui); font-size: 2rem; color: var(--text-main); text-transform: uppercase; letter-spacing: 2px; text-shadow: 0 0 10px var(--accent-dim); }
+.brand span { font-family: var(--font-code); font-size: 0.8rem; color: var(--accent-core); }
 nav ul { list-style: none; display: flex; gap: var(--space-lg); }
 nav a { color: var(--text-muted); text-decoration: none; font-family: var(--font-ui); font-size: 1.1rem; text-transform: uppercase; transition: 0.3s; }
-nav a:hover { color: var(--cyan-core); text-shadow: 0 0 8px var(--cyan-dim); }
-nav a.nav-highlight { color: var(--cyan-core); }
+nav a:hover { color: var(--accent-core); text-shadow: 0 0 8px var(--accent-dim); }
+nav a.nav-highlight { color: var(--accent-core); }
 
 section { margin-bottom: var(--space-xl); }
 .section-title {
   font-family: var(--font-ui); font-size: 2.2rem; color: var(--text-main); margin-bottom: var(--space-lg);
   display: flex; align-items: center; gap: var(--space-md);
 }
-.section-title::before { content: ''; display: block; width: 12px; height: 12px; background: var(--cyan-core); box-shadow: 0 0 10px var(--cyan-dim); }
+.section-title::before { content: ''; display: block; width: 12px; height: 12px; background: var(--accent-core); box-shadow: 0 0 10px var(--accent-dim); }
 
 .hud-card {
-  background: var(--bg-surface); 
-  border: 1px solid var(--cyan-border); 
+  background: var(--bg-surface);
+  border: 1px solid var(--accent-border);
   border-radius: 8px;
-  padding: var(--space-lg); 
-  display: flex; 
-  flex-direction: column; 
-  transition: all 0.3s;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.35s cubic-bezier(.2,.8,.2,1), border-color 0.35s cubic-bezier(.2,.8,.2,1),
+    box-shadow 0.35s cubic-bezier(.2,.8,.2,1), background 0.4s ease;
   backdrop-filter: blur(10px);
-  color: var(--text-main); 
+  color: var(--text-main);
 }
 .hud-card p, .hud-card strong {
   color: var(--text-main);
 }
-.hud-card:hover { 
-  transform: translateY(-3px); 
-  border-color: var(--cyan-core); 
-  box-shadow: 0 5px 20px var(--cyan-dim); 
+.hud-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent-core);
+  box-shadow: 0 8px 28px var(--accent-dim);
 }
 
 .high-contrast-mode .hud-card { border-width: 2px; box-shadow: none !important; }
 
-.card-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-md); border-bottom: 1px dashed var(--cyan-dim); padding-bottom: var(--space-sm); }
+.card-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: var(--space-md); border-bottom: 1px dashed var(--accent-dim); padding-bottom: var(--space-sm); }
 .card-title { font-family: var(--font-ui); font-size: 1.6rem; color: var(--text-main); margin-bottom: 0; }
-.card-period { font-family: var(--font-code); font-size: 0.85rem; color: var(--cyan-core); }
+.card-period { font-family: var(--font-code); font-size: 0.85rem; color: var(--accent-core); }
 
 .card-desc { color: var(--text-main); font-size: 0.95rem; flex-grow: 1; margin-bottom: var(--space-lg); }
 .card-desc p, .card-desc ul, .card-desc li { color: var(--text-main) !important; }
@@ -347,30 +408,42 @@ section { margin-bottom: var(--space-xl); }
 .project-grid { display: grid; grid-template-columns: 1fr; gap: var(--space-lg); }
 
 .tech-list { list-style: none; display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-bottom: var(--space-lg); }
-.tech-tag { font-family: var(--font-code); font-size: 0.75rem; color: var(--cyan-core); background: var(--cyan-dim); border: 1px dashed var(--cyan-border); padding: 4px 8px; border-radius: 4px; }
+.tech-tag { font-family: var(--font-code); font-size: 0.75rem; color: var(--accent-core); background: var(--accent-dim); border: 1px dashed var(--accent-border); padding: 4px 8px; border-radius: 4px; }
 
-.btn-hud { display: inline-flex; align-items: center; gap: 8px; background: var(--cyan-dim); color: var(--cyan-core); border: 1px solid var(--cyan-border); padding: 8px 16px; font-family: var(--font-ui); font-size: 1.1rem; text-decoration: none; text-transform: uppercase; transition: all 0.3s; align-self: flex-start; }
-.btn-hud:hover { background: var(--cyan-core); color: var(--bg-base); box-shadow: 0 0 15px var(--cyan-dim); }
-.btn-hud--live { background: var(--cyan-core); color: var(--bg-base); font-weight: 700; }
-.btn-hud--live:hover { box-shadow: 0 0 25px var(--cyan-core); opacity: 0.85; }
+.btn-hud {
+  display: inline-flex; align-items: center; gap: 8px; background: var(--accent-dim); color: var(--accent-core);
+  border: 1px solid var(--accent-border); padding: 8px 16px; font-family: var(--font-ui); font-size: 1.1rem;
+  text-decoration: none; text-transform: uppercase; align-self: flex-start;
+  transition: background 0.3s cubic-bezier(.2,.8,.2,1), color 0.3s cubic-bezier(.2,.8,.2,1),
+    box-shadow 0.3s cubic-bezier(.2,.8,.2,1), transform 0.3s cubic-bezier(.2,.8,.2,1);
+}
+.btn-hud:hover {
+  background: var(--accent-core); color: var(--bg-base);
+  box-shadow: 0 0 18px var(--accent-dim); transform: translateY(-2px) scale(1.02);
+}
+.btn-hud--live { background: var(--accent-core); color: var(--bg-base); font-weight: 700; }
+.btn-hud--live:hover {
+  box-shadow: 0 0 26px var(--accent-warm); background: var(--accent-warm);
+  transform: translateY(-2px) scale(1.02);
+}
 
 .timeline { list-style: none; position: relative; padding-left: 30px; }
 .timeline::before {
   content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
-  background: linear-gradient(to bottom, var(--cyan-core), transparent);
+  background: linear-gradient(to bottom, var(--accent-core), transparent);
 }
 .timeline-item { position: relative; margin-bottom: var(--space-lg); }
 .timeline-item::before {
   content: ''; position: absolute; left: -36px; top: 6px; width: 14px; height: 14px;
-  background: var(--bg-base); border: 2px solid var(--cyan-core); border-radius: 50%;
-  box-shadow: 0 0 10px var(--cyan-dim); transition: background 0.4s;
+  background: var(--bg-base); border: 2px solid var(--accent-core); border-radius: 50%;
+  box-shadow: 0 0 10px var(--accent-dim); transition: background 0.4s;
 }
-.timeline-date { font-family: var(--font-code); font-size: 0.85rem; color: var(--cyan-core); margin-bottom: 4px; display: block; }
+.timeline-date { font-family: var(--font-code); font-size: 0.85rem; color: var(--accent-core); margin-bottom: 4px; display: block; }
 .timeline-title { font-family: var(--font-ui); font-size: 1.3rem; color: var(--text-main); margin-bottom: 2px; }
 .timeline-org { font-weight: 600; color: var(--text-main); font-size: 1rem; margin-bottom: 8px; }
 .timeline-desc { color: var(--text-muted); font-size: 0.95rem; }
 
-footer { border-top: 1px solid var(--cyan-border); padding: var(--space-lg) 0; text-align: center; font-family: var(--font-code); font-size: 0.8rem; color: var(--text-muted); }
+footer { border-top: 1px solid var(--accent-border); padding: var(--space-lg) 0; text-align: center; font-family: var(--font-code); font-size: 0.8rem; color: var(--text-muted); }
 
 /* =========================================
    RESPONSIVIDADE E DISTÚRBIOS VESTIBULARES
@@ -391,7 +464,6 @@ footer { border-top: 1px solid var(--cyan-border); padding: var(--space-lg) 0; t
      pra parecer um aplicativo separado em vez de uma página comum. */
   .app-mode.container {
     padding: 0;
-    background-image: none;
     min-height: 100dvh;
   }
   .app-mode .skip-link {

--- a/src/components/HeroTerminal.vue
+++ b/src/components/HeroTerminal.vue
@@ -148,8 +148,8 @@ export default {
   align-items: center;
   gap: 8px;
   padding: 10px var(--space-md);
-  border-bottom: 1px solid var(--cyan-border);
-  background: var(--cyan-dim);
+  border-bottom: 1px solid var(--accent-border);
+  background: var(--accent-dim);
 }
 .term-dot {
   width: 12px; height: 12px; border-radius: 50%;
@@ -173,13 +173,13 @@ export default {
   overflow-y: auto;
 }
 .term-line { white-space: pre-wrap; word-break: break-word; color: var(--text-main); }
-.term-line--system { color: var(--cyan-core); }
+.term-line--system { color: var(--accent-core); }
 .term-line--input { color: var(--text-main); }
 .term-line--error { color: #ff6b6b; }
 .high-contrast-mode .term-line--error { color: #ffff00; }
 
 .term-prompt {
-  color: var(--cyan-core);
+  color: var(--accent-core);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -196,7 +196,7 @@ export default {
   color: var(--text-main);
   font-family: var(--font-code);
   font-size: 0.85rem;
-  caret-color: var(--cyan-core);
+  caret-color: var(--accent-core);
   min-width: 0;
 }
 .term-input-row input::placeholder { color: var(--text-muted); opacity: 0.7; }

--- a/src/components/ProjectPreviewModal.vue
+++ b/src/components/ProjectPreviewModal.vue
@@ -111,7 +111,7 @@ export default {
 .preview-modal {
   background: var(--bg-surface);
   border: 1px solid var(--accent-border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   max-width: 900px;
   width: 100%;
   max-height: 90vh;
@@ -137,7 +137,7 @@ export default {
   background: transparent;
   border: 1px solid var(--accent-border);
   color: var(--text-main);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   width: 36px;
   height: 36px;
   cursor: pointer;
@@ -155,7 +155,7 @@ export default {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--accent-dim);
 }
 

--- a/src/components/ProjectPreviewModal.vue
+++ b/src/components/ProjectPreviewModal.vue
@@ -99,7 +99,7 @@ export default {
 .preview-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(3, 5, 9, 0.88);
+  background: var(--scrim-overlay);
   backdrop-filter: blur(6px);
   display: flex;
   align-items: center;
@@ -110,7 +110,7 @@ export default {
 
 .preview-modal {
   background: var(--bg-surface);
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   border-radius: 12px;
   max-width: 900px;
   width: 100%;
@@ -118,7 +118,7 @@ export default {
   display: flex;
   flex-direction: column;
   padding: var(--space-lg);
-  box-shadow: 0 0 40px var(--cyan-dim);
+  box-shadow: 0 0 40px var(--accent-dim);
 }
 
 .preview-header {
@@ -135,7 +135,7 @@ export default {
 
 .preview-close {
   background: transparent;
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   color: var(--text-main);
   border-radius: 6px;
   width: 36px;
@@ -145,7 +145,7 @@ export default {
   transition: all 0.2s;
 }
 .preview-close:hover, .preview-close:focus-visible {
-  background: var(--cyan-core);
+  background: var(--accent-core);
   color: var(--bg-base);
 }
 
@@ -156,7 +156,7 @@ export default {
   justify-content: center;
   overflow: hidden;
   border-radius: 8px;
-  border: 1px solid var(--cyan-dim);
+  border: 1px solid var(--accent-dim);
 }
 
 .preview-image {
@@ -173,8 +173,8 @@ export default {
   top: 50%;
   transform: translateY(-50%);
   background: var(--bg-surface);
-  border: 1px solid var(--cyan-border);
-  color: var(--cyan-core);
+  border: 1px solid var(--accent-border);
+  color: var(--accent-core);
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -183,7 +183,7 @@ export default {
   z-index: 1;
 }
 .preview-nav:hover, .preview-nav:focus-visible {
-  background: var(--cyan-core);
+  background: var(--accent-core);
   color: var(--bg-base);
 }
 .preview-nav--prev { left: var(--space-md); }
@@ -207,14 +207,14 @@ export default {
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   background: transparent;
   cursor: pointer;
   padding: 0;
 }
 .preview-dot--active {
-  background: var(--cyan-core);
-  box-shadow: 0 0 8px var(--cyan-dim);
+  background: var(--accent-core);
+  box-shadow: 0 0 8px var(--accent-dim);
 }
 
 @media (max-width: 600px) {

--- a/src/views/Arcade.vue
+++ b/src/views/Arcade.vue
@@ -93,6 +93,6 @@ export default {
 .arcade-icon {
   font-size: 2rem;
   margin-bottom: var(--space-sm);
-  filter: drop-shadow(0 0 8px var(--cyan-dim));
+  filter: drop-shadow(0 0 8px var(--accent-dim));
 }
 </style>

--- a/src/views/CheckersGame.vue
+++ b/src/views/CheckersGame.vue
@@ -283,10 +283,10 @@ export default {
   margin: 0 calc(-1 * var(--space-lg)) var(--space-md);
   background: var(--bg-surface);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--cyan-border);
+  border-bottom: 1px solid var(--accent-border);
 }
 .dm-app-back {
-  color: var(--cyan-core);
+  color: var(--accent-core);
   text-decoration: none;
   font-family: var(--font-ui);
   font-size: 1rem;
@@ -332,20 +332,20 @@ export default {
 .dm-control-row label {
   font-family: var(--font-code);
   font-size: 0.75rem;
-  color: var(--cyan-core);
+  color: var(--accent-core);
   text-transform: uppercase;
 }
 .dm-control-row select {
   background: var(--bg-surface);
   color: var(--text-main);
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   border-radius: 4px;
   padding: 6px 8px;
   font-family: var(--font-read);
   font-size: 0.9rem;
 }
 .dm-panel-divider {
-  border-top: 1px dashed var(--cyan-dim);
+  border-top: 1px dashed var(--accent-dim);
   margin: var(--space-sm) 0;
 }
 .dm-message {
@@ -372,8 +372,8 @@ export default {
   grid-template-columns: repeat(8, 1fr);
   width: min(92vw, 560px);
   aspect-ratio: 1;
-  border: 2px solid var(--cyan-border);
-  box-shadow: 0 0 25px var(--cyan-dim);
+  border: 2px solid var(--accent-border);
+  box-shadow: 0 0 25px var(--accent-dim);
 }
 .dm-square {
   position: relative;
@@ -386,17 +386,17 @@ export default {
   justify-content: center;
 }
 .dm-square--dark {
-  background: rgba(0, 229, 255, 0.14);
+  background: var(--accent-dim);
 }
 .light-mode .dm-square { background: #e8eef6; }
 .light-mode .dm-square--dark { background: #9db8d4; }
 .dm-square:not(:disabled) { cursor: pointer; }
 .dm-square--selected {
-  outline: 2px solid var(--cyan-core);
+  outline: 2px solid var(--accent-core);
   outline-offset: -2px;
 }
 .dm-square--last {
-  box-shadow: inset 0 0 0 2px rgba(0, 229, 255, 0.45);
+  box-shadow: inset 0 0 0 2px var(--accent-core);
 }
 
 .dm-piece {
@@ -417,7 +417,7 @@ export default {
 .dm-piece--black {
   background: radial-gradient(circle at 33% 30%, #3c4654, #0b111a 75%);
   border: 1px solid #05080d;
-  color: #00e5ff;
+  color: var(--accent-core);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
 }
 .dm-crown { line-height: 1; }
@@ -427,7 +427,7 @@ export default {
   width: 34%;
   height: 34%;
   border-radius: 50%;
-  background: var(--cyan-core);
+  background: var(--accent-core);
   opacity: 0.55;
   animation: dm-pulse 1.2s ease-in-out infinite;
   pointer-events: none;

--- a/src/views/GoGame.vue
+++ b/src/views/GoGame.vue
@@ -495,10 +495,10 @@ export default {
   margin: 0 calc(-1 * var(--space-lg)) var(--space-md);
   background: var(--bg-surface);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--cyan-border);
+  border-bottom: 1px solid var(--accent-border);
 }
 .go-app-back {
-  color: var(--cyan-core);
+  color: var(--accent-core);
   text-decoration: none;
   font-family: var(--font-ui);
   font-size: 1rem;
@@ -548,13 +548,13 @@ export default {
 .go-control-row label {
   font-family: var(--font-code);
   font-size: 0.75rem;
-  color: var(--cyan-core);
+  color: var(--accent-core);
   text-transform: uppercase;
 }
 .go-control-row select {
   background: var(--bg-surface);
   color: var(--text-main);
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   border-radius: 4px;
   padding: 6px 8px;
   font-family: var(--font-read);
@@ -562,7 +562,7 @@ export default {
 }
 
 .go-panel-divider {
-  border-top: 1px dashed var(--cyan-dim);
+  border-top: 1px dashed var(--accent-dim);
   margin: var(--space-sm) 0;
 }
 .go-message {
@@ -598,7 +598,7 @@ export default {
   gap: 8px;
   margin-top: 6px;
   padding-top: var(--space-sm);
-  border-top: 1px dashed var(--cyan-dim);
+  border-top: 1px dashed var(--accent-dim);
 }
 .go-coord-form label {
   font-family: var(--font-code);
@@ -612,7 +612,7 @@ export default {
 .go-coord-inputs input {
   background: var(--bg-surface);
   color: var(--text-main);
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   border-radius: 4px;
   padding: 6px 8px;
   width: 110px;
@@ -634,7 +634,7 @@ export default {
 .go-board-card.hud-card:hover {
   transform: none;
   box-shadow: none;
-  border-color: var(--cyan-border);
+  border-color: var(--accent-border);
 }
 .go-board-outer {
   overflow-x: auto;
@@ -814,7 +814,7 @@ export default {
   left: 50%;
   width: 26%;
   height: 26%;
-  border: 2px solid #00e5ff;
+  border: 2px solid var(--accent-core);
   border-radius: 50%;
   transform: translate(-50%, -50%);
   pointer-events: none;
@@ -868,23 +868,23 @@ export default {
 }
 .score-table th,
 .score-table td {
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   padding: 8px 12px;
   text-align: center;
   color: var(--text-main);
 }
 .score-table thead th {
-  color: var(--cyan-core);
+  color: var(--accent-core);
 }
 .score-total th,
 .score-total td {
   font-weight: 700;
-  background: var(--cyan-dim);
+  background: var(--accent-dim);
 }
 .result-headline {
   font-family: var(--font-ui);
   font-size: 1.3rem;
-  color: var(--cyan-core);
+  color: var(--accent-core);
 }
 
 @media (max-width: 768px) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -49,7 +49,7 @@
           <span class="timeline-date">{{ item.period }}</span>
           <h3 class="timeline-title">{{ item.role }}</h3>
           <div class="timeline-org">{{ item.company }}</div>
-          <p v-if="item.description" class="timeline-desc" style="color: var(--cyan-core); font-size: 0.85rem; margin-top: 4px;">{{ item.description }}</p>
+          <p v-if="item.description" class="timeline-desc" style="color: var(--accent-core); font-size: 0.85rem; margin-top: 4px;">{{ item.description }}</p>
         </li>
       </ol>
     </section>

--- a/src/views/MemoryGame.vue
+++ b/src/views/MemoryGame.vue
@@ -223,10 +223,10 @@ export default {
   margin: 0 calc(-1 * var(--space-lg)) var(--space-md);
   background: var(--bg-surface);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--cyan-border);
+  border-bottom: 1px solid var(--accent-border);
 }
 .mm-app-back {
-  color: var(--cyan-core);
+  color: var(--accent-core);
   text-decoration: none;
   font-family: var(--font-ui);
   font-size: 1rem;
@@ -267,20 +267,20 @@ export default {
 .mm-control-row label {
   font-family: var(--font-code);
   font-size: 0.75rem;
-  color: var(--cyan-core);
+  color: var(--accent-core);
   text-transform: uppercase;
 }
 .mm-control-row select {
   background: var(--bg-surface);
   color: var(--text-main);
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
   border-radius: 4px;
   padding: 6px 8px;
   font-family: var(--font-read);
   font-size: 0.9rem;
 }
 .mm-panel-divider {
-  border-top: 1px dashed var(--cyan-dim);
+  border-top: 1px dashed var(--accent-dim);
   margin: var(--space-sm) 0;
 }
 .mm-stats {
@@ -343,29 +343,29 @@ export default {
   gap: 4px;
   backface-visibility: hidden;
   border-radius: 8px;
-  border: 1px solid var(--cyan-border);
+  border: 1px solid var(--accent-border);
 }
 .mm-card-back {
   background:
-    repeating-linear-gradient(45deg, var(--cyan-dim) 0 6px, transparent 6px 12px),
+    repeating-linear-gradient(45deg, var(--accent-dim) 0 6px, transparent 6px 12px),
     var(--bg-surface);
-  border-color: var(--cyan-core);
-  box-shadow: inset 0 0 12px var(--cyan-dim);
-  color: var(--cyan-core);
+  border-color: var(--accent-core);
+  box-shadow: inset 0 0 12px var(--accent-dim);
+  color: var(--accent-core);
   font-family: var(--font-code);
   font-size: 1.2rem;
 }
 .mm-card:not(:disabled):hover .mm-card-back {
-  box-shadow: 0 0 15px var(--cyan-dim);
-  border-color: var(--cyan-core);
+  box-shadow: 0 0 15px var(--accent-dim);
+  border-color: var(--accent-core);
 }
 .mm-card-front {
   background: var(--bg-surface);
   transform: rotateY(180deg);
 }
 .mm-card--matched .mm-card-front {
-  border-color: var(--cyan-core);
-  box-shadow: 0 0 12px var(--cyan-dim);
+  border-color: var(--accent-core);
+  box-shadow: 0 0 12px var(--accent-dim);
 }
 .mm-glyph { font-size: clamp(1.2rem, 5vw, 2rem); }
 .mm-label {
@@ -383,17 +383,17 @@ export default {
   align-items: center;
   gap: var(--space-sm);
   padding: var(--space-md);
-  border: 1px dashed var(--cyan-border);
+  border: 1px dashed var(--accent-border);
   border-radius: 8px;
   width: 100%;
 }
 .mm-victory-title {
   font-family: var(--font-code);
-  color: var(--cyan-core);
+  color: var(--accent-core);
   letter-spacing: 2px;
 }
 .mm-victory p { color: var(--text-main); }
-.mm-record { color: var(--cyan-core); font-weight: 600; }
+.mm-record { color: var(--accent-core); font-weight: 600; }
 
 @media (max-width: 768px) {
   .mm-app-bar { margin: 0 0 var(--space-md); }

--- a/src/views/Resources.vue
+++ b/src/views/Resources.vue
@@ -213,7 +213,7 @@ export default {
 <style scoped>
 .res-intro { margin-bottom: var(--space-lg); }
 .res-intro p { color: var(--text-main); }
-.res-intro a { color: var(--cyan-core); }
+.res-intro a { color: var(--accent-core); }
 
 .res-category { margin-bottom: var(--space-xl); }
 .res-category-title {
@@ -244,8 +244,8 @@ export default {
   padding: var(--space-md);
 }
 .res-card--featured {
-  border-color: var(--cyan-core);
-  box-shadow: 0 0 18px var(--cyan-dim);
+  border-color: var(--accent-core);
+  box-shadow: 0 0 18px var(--accent-dim);
 }
 .res-card-top {
   display: flex;
@@ -261,7 +261,7 @@ export default {
 .res-badge {
   font-family: var(--font-code);
   font-size: 0.7rem;
-  background: var(--cyan-core);
+  background: var(--accent-core);
   color: var(--bg-base);
   padding: 2px 8px;
   border-radius: 4px;
@@ -272,8 +272,8 @@ export default {
 .res-lang {
   font-family: var(--font-code);
   font-size: 0.7rem;
-  color: var(--cyan-core);
-  border: 1px dashed var(--cyan-border);
+  color: var(--accent-core);
+  border: 1px dashed var(--accent-border);
   padding: 2px 8px;
   border-radius: 4px;
   white-space: nowrap;
@@ -287,6 +287,6 @@ export default {
 .res-url {
   font-family: var(--font-code);
   font-size: 0.75rem;
-  color: var(--cyan-core);
+  color: var(--accent-core);
 }
 </style>

--- a/src/views/Resources.vue
+++ b/src/views/Resources.vue
@@ -264,7 +264,7 @@ export default {
   background: var(--accent-core);
   color: var(--bg-base);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   text-transform: uppercase;
   font-weight: 700;
   white-space: nowrap;
@@ -273,9 +273,9 @@ export default {
   font-family: var(--font-code);
   font-size: 0.7rem;
   color: var(--accent-core);
-  border: 1px dashed var(--accent-border);
+  border: 1px solid var(--accent-border);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
 }
 .res-desc {


### PR DESCRIPTION
## Summary
- Substitui o tema sci-fi ciano por uma paleta Índigo/Violeta com acento Âmbar (dark e light mode), com ícones de TI (`</>`, `{}`, nuvem, banco de dados, git-branch, terminal, wifi, CPU, etc.) flutuando lentamente no fundo em vez da antiga grade de pontos.
- Renomeia as variáveis de tema `--cyan-*` para `--accent-*` e refina as transições de hover em botões/cards com a nova cor.
- Menu de navegação agora exibe todos os itens em qualquer página (antes só a Home tinha o menu completo), com um botão "← Portfólio" destacado nas páginas internas; os itens Arcade/Recursos/Serviços ganham uma borda fina para se diferenciar dos demais sem depender só de cor.
- Cantos mais arredondados em cards, botões, tags e no modal de preview, sombra suave nos cards e uma linha divisória sob cada título de seção, para dar uma cara mais moderna/clean e deixar claro onde uma seção termina e outra começa.

## Test plan
- [x] `npm run build` roda sem erros
- [x] Testado visualmente (dark e light mode) via `vite preview` + Playwright: Home, Recursos, Serviços, Damas, Go
- [x] Modo de alto contraste continua 100% sólido (sem ícones de fundo)
- [ ] Revisão visual final no navegador pelo usuário

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qMSiZuP5YKwf4LTRZF9FQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013qMSiZuP5YKwf4LTRZF9FQ)_