### PR TITLE
Prerender da Home + meta tags OG/Twitter (fix link preview e indexação)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rebeca Nonato | Software Engineer</title>
+    <meta name="description" content="Engenheira de Software com +7 anos de experiência em sistemas distribuídos, microsserviços cloud-native e arquitetura orientada a eventos (Kotlin, Java, Node.js, AWS)." />
+    <link rel="canonical" href="https://rebecanonato89.dev/" />
+
+    <meta property="og:type" content="profile" />
+    <meta property="og:url" content="https://rebecanonato89.dev/" />
+    <meta property="og:title" content="Rebeca Nonato | Software Engineer" />
+    <meta property="og:description" content="Engenheira de Software com +7 anos de experiência em sistemas distribuídos, microsserviços cloud-native e arquitetura orientada a eventos (Kotlin, Java, Node.js, AWS)." />
+    <meta property="og:locale" content="pt_BR" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Rebeca Nonato | Software Engineer" />
+    <meta name="twitter:description" content="Engenheira de Software com +7 anos de experiência em sistemas distribuídos, microsserviços cloud-native e arquitetura orientada a eventos (Kotlin, Java, Node.js, AWS)." />
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Rajdhani:wght@500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && vite build --ssr src/entry-server.js --outDir dist-ssr && node scripts/prerender.mjs",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",
+    "@vue/server-renderer": "^3.4.0",
     "vite": "^5.0.0"
   }
 }

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,34 @@
+// Injeta o HTML da rota "/" (a única que um bot vê, já que o app usa hash
+// routing) no dist/index.html gerado pelo `vite build`, usando o bundle SSR
+// gerado por `vite build --ssr src/entry-server.js --outDir dist-ssr`.
+// Roda como último passo de `npm run build`; dist-ssr é descartado no final,
+// pois só existe pra gerar esse snapshot em build time (não é servido).
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.dirname(fileURLToPath(new URL('.', import.meta.url)));
+const distDir = path.join(rootDir, 'dist');
+const ssrDir = path.join(rootDir, 'dist-ssr');
+const ssrEntry = path.join(ssrDir, 'entry-server.mjs');
+
+const { render } = await import(pathToFileUrl(ssrEntry));
+const appHtml = await render('/');
+
+const indexPath = path.join(distDir, 'index.html');
+const original = readFileSync(indexPath, 'utf-8');
+
+if (!original.includes('<div id="app"></div>')) {
+  throw new Error('prerender: <div id="app"></div> não encontrado em dist/index.html');
+}
+
+const prerendered = original.replace('<div id="app"></div>', `<div id="app">${appHtml}</div>`);
+writeFileSync(indexPath, prerendered);
+
+rmSync(ssrDir, { recursive: true, force: true });
+
+console.log('[prerender] conteúdo estático da Home injetado em dist/index.html');
+
+function pathToFileUrl(p) {
+  return new URL(`file://${p}`).href;
+}

--- a/src/entry-server.js
+++ b/src/entry-server.js
@@ -1,0 +1,19 @@
+import { createSSRApp } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import App from './App.vue';
+import { createAppRouter } from './router/index.js';
+import { createMemoryHistory } from 'vue-router';
+
+// Usado só em build time (scripts/prerender.js) para gerar o HTML estático da
+// rota "/" — a única que importa pro crawler, já que o app usa hash routing
+// (o servidor nunca vê o fragmento depois do #).
+export async function render(url = '/') {
+  const app = createSSRApp(App);
+  const router = createAppRouter(createMemoryHistory());
+  app.use(router);
+
+  router.push(url);
+  await router.isReady();
+
+  return renderToString(app);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
+import { createWebHashHistory } from 'vue-router';
 import App from './App.vue';
-import router from './router/index.js';
+import { createAppRouter } from './router/index.js';
 
-createApp(App).use(router).mount('#app');
+createApp(App).use(createAppRouter(createWebHashHistory())).mount('#app');

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter } from 'vue-router';
 import Home from '../views/Home.vue';
 import GoGame from '../views/GoGame.vue';
 import CheckersGame from '../views/CheckersGame.vue';
@@ -12,7 +12,7 @@ import CertificacoesCode from '../views/CertificacoesCode.vue';
 import DeploymentsCode from '../views/DeploymentsCode.vue';
 import ContatoCode from '../views/ContatoCode.vue';
 
-const routes = [
+export const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/arcade', name: 'arcade', component: Arcade },
   { path: '/go', name: 'go-game', component: GoGame },
@@ -27,14 +27,20 @@ const routes = [
   { path: '/contato', name: 'contato-code', component: ContatoCode },
 ];
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes,
-  scrollBehavior(to, from, savedPosition) {
-    if (savedPosition) return savedPosition;
-    if (to.hash) return { el: to.hash, behavior: 'smooth' };
-    return { top: 0 };
-  }
-});
-
-export default router;
+// Fábrica de router: o client usa hash history (createWebHashHistory, chamado
+// em main.js), mas o prerender de build (entry-server.js) precisa de uma
+// instância isolada com createMemoryHistory para renderizar a rota "/" fora
+// do browser — por isso a criação da history fica fora deste módulo: chamar
+// createWebHashHistory() aqui no topo do arquivo quebraria o build SSR
+// (referencia `location`, que não existe em Node).
+export function createAppRouter(history) {
+  return createRouter({
+    history,
+    routes,
+    scrollBehavior(to, from, savedPosition) {
+      if (savedPosition) return savedPosition;
+      if (to.hash) return { el: to.hash, behavior: 'smooth' };
+      return { top: 0 };
+    }
+  });
+}


### PR DESCRIPTION
## Contexto

O site (`rebecanonato89.dev`) é uma SPA Vue 3 com roteamento por hash (`createWebHashHistory`), renderizada 100% no client. Um `fetch` simples na URL (o que ferramentas de preview de link — LinkedIn, WhatsApp — e crawlers sem execução de JS fazem) retornava só o `<title>`, sem conteúdo algum. Como o roteamento é por hash, o servidor nunca vê o que vem depois do `#` de qualquer forma — ou seja, todo bot bate sempre em `/`, então prerenderizar essa única rota já cobre o problema real.

## Mudanças

- **`index.html`**: adiciona `description`, `canonical` e meta tags Open Graph/Twitter Card. Isso sozinho já resolve o preview quebrado em si — essas ferramentas leem só as meta tags, não o body renderizado.
- **`src/entry-server.js`** (novo): renderiza a rota `/` para string via `@vue/server-renderer`, usando uma instância de router isolada com `createMemoryHistory` (SSR não pode depender de `location`, que não existe em Node).
- **`scripts/prerender.mjs`** (novo): passo de pós-build que builda o bundle SSR (`vite build --ssr`), chama `render('/')` e injeta o HTML resultante em `dist/index.html`, no lugar de `<div id="app"></div>`. `dist-ssr` é descartado no final — só existe para gerar esse snapshot em build time.
- **`src/router/index.js`**: em vez de exportar uma instância fixa de router criada com `createWebHashHistory()` no topo do módulo (o que quebra o build SSR, já que `createWebHashHistory()` referencia `location`), agora exporta uma fábrica `createAppRouter(history)`. O client (`main.js`) continua usando hash history normalmente.
- **`package.json`**: `npm run build` agora roda `vite build && vite build --ssr src/entry-server.js --outDir dist-ssr && node scripts/prerender.mjs`.

## Resultado

`dist/index.html` foi de 1.8 kB (só `<title>` + shell vazio) para ~44 kB com todo o conteúdo da Home renderizado (experiência, formação, projetos, etc.) presente no HTML estático.

## Test plan

- [x] `npm run build` roda sem erros e produz `dist/index.html` com o conteúdo prerenderizado (verificado via `grep` por textos das seções de experiência/projetos).
- [x] `npm run preview` + `curl` confirmam que o HTML servido (sem JS) já contém o conteúdo completo.
- [x] Verificado em Chromium headless (Playwright) que o app ainda monta e funciona normalmente no client (sidebar, navegação, tema) após o JS carregar, sem erros de console novos — os únicos erros de rede observados são falhas ao carregar Google Fonts, bloqueadas pelo sandbox de rede do ambiente de teste, não relacionadas a esta mudança.


---
_Generated by [Claude Code](https://claude.ai/code/session_015HfYqLQtcSLwsvckYL2d9g)_