### PR TITLE
Atualiza experiência, certificações e projetos com dados do currículo/LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Engenheira de Software com mais de 7 anos de experiência, focada no desenho, implementação e sustentação de arquiteturas escaláveis. Priorizo a construção de sistemas sob restrições reais: consistência de dados, segurança corporativa, observabilidade e resiliência. 
 
-Possuo amplo histórico no gerenciamento de incidentes críticos (war rooms, P1/P2) em ambientes AWS e aplico rigorosamente padrões como Clean Architecture, Hexagonal e mensageria orientada a eventos. Todo código que produzo reflete decisões técnicas explícitas e mitigação direta de gargalos.
+Atualmente na **Alice (health tech)**, desenvolvendo backend em Kotlin (JVM) com arquitetura orientada a eventos. Antes, 5 anos na Accenture como referência técnica em ambientes de microsserviços, com amplo histórico no gerenciamento de incidentes críticos (war rooms, P1/P2) em AWS. Aplico rigorosamente padrões como Clean Architecture, Hexagonal e mensageria orientada a eventos — todo código que produzo reflete decisões técnicas explícitas e mitigação direta de gargalos.
 
 [Portfólio](https://rebecanonato89.dev) · [LinkedIn](https://www.linkedin.com/in/rebecanonato89/) · [Email](mailto:rebeca.nonato.dev@gmail.com)
 
@@ -28,7 +28,7 @@ Possuo amplo histórico no gerenciamento de incidentes críticos (war rooms, P1/
 | **[Hedge CLI](https://github.com/rebecanonato89/hedge-cli)** | Detector híbrido via AST (tree-sitter) e heurística para identificação de *Eager Test* em suites Java, operando com LLM gating (ativação estrita sob demanda). | Python, AST, LLMs, ML |
 | **[Food Fiapp](https://github.com/fiap-tech-challenge-java/food-fiapp)** | API de gestão seguindo Clean Architecture. Acoplamento mínimo, cobertura de testes automatizados superior a 90% (JUnit 5, Mockito, ArchUnit) e integração com object storage. | Java 21, MinIO, Docker |
 | **[TechChallenge](https://github.com/fiap-tech-challenge-java/fiap-tech-challenge)** | API REST para gestão de usuários. Domínio isolado via Arquitetura Hexagonal, segurança via Spring Security (JWT/RBAC) e contratos expostos via OpenAPI. | Java 21, Spring Security |
-| **Equinox Solar CRM** | CRM full-stack com integrações via Docker. Em paralelo, atua como ambiente de pesquisa para aplicação de técnicas de Machine Learning na otimização de testes de software. | NestJS, ML, Python, NLP |
+| **Equinox Solar CRM** | CRM full-stack para gestão comercial de projetos de energia solar, containerizado com Docker. | NestJS, Next.js, Docker |
 
 ---
 
@@ -44,6 +44,7 @@ Possuo amplo histórico no gerenciamento de incidentes críticos (war rooms, P1/
 * **Reinvention with Agentic AI** (Accenture, Dez 2025)
 * **AWS Educate Machine Learning Foundations** (AWS, Jun 2025)
 * **Introducing Generative AI with AWS** (Udacity, Jun 2025)
+* **AWS Certified Cloud Practitioner** (AWS, 2024)
 * **Especialização em Arquitetura e Desenvolvimento Java** (FIAP, 2024 - 2026)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.0",
+        "@vue/server-renderer": "^3.4.0",
         "vite": "^5.0.0"
       }
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -161,6 +161,7 @@ const PATH_META = {
   '/sobre': { label: 'sobre.md', icon: 'md', breadcrumb: ['src', 'views', 'SobreCode.vue'] },
   '/experiencia': { label: 'experiencia.log', icon: 'log', breadcrumb: ['src', 'views', 'ExperienciaCode.vue'] },
   '/certificacoes': { label: 'certificacoes.log', icon: 'log', breadcrumb: ['src', 'views', 'CertificacoesCode.vue'] },
+  '/publicacoes': { label: 'publicacoes.log', icon: 'log', breadcrumb: ['src', 'views', 'PublicacoesCode.vue'] },
   '/projetos': { label: 'deployments.json', icon: 'json', breadcrumb: ['src', 'views', 'DeploymentsCode.vue'] },
   '/contato': { label: 'contato.md', icon: 'md', breadcrumb: ['src', 'views', 'ContatoCode.vue'] },
   '/arcade': { label: 'arcade.vue', icon: 'vue', breadcrumb: ['src', 'views', 'Arcade.vue'] },
@@ -188,6 +189,7 @@ export default {
                 { id: 'sobre', label: 'sobre.md', type: 'file', icon: 'md', path: '/sobre' },
                 { id: 'experiencia', label: 'experiencia.log', type: 'file', icon: 'log', path: '/experiencia' },
                 { id: 'certificacoes', label: 'certificacoes.log', type: 'file', icon: 'log', path: '/certificacoes' },
+                { id: 'publicacoes', label: 'publicacoes.log', type: 'file', icon: 'log', path: '/publicacoes' },
               ],
             },
             {

--- a/src/data/profileData.js
+++ b/src/data/profileData.js
@@ -4,10 +4,22 @@
 
 export const experienceData = [
   {
-    role: 'Application Development Analyst (Senior Backend)',
+    role: 'Software Engineer (Backend)',
+    company: 'Alice (health tech)',
+    period: 'Mar 2026 - Presente',
+    description: 'Desenvolvimento backend em Kotlin (JVM) em arquitetura orientada a eventos, com mensageria, em plataforma de saúde com requisitos de confiabilidade. Fluxo de desenvolvimento AI-native operado via terminal: planejamento, git worktrees, TDD, commits, criação de PRs e monitoramento pós-deploy.'
+  },
+  {
+    role: 'Application Development Specialist (Senior Backend)',
     company: 'Accenture',
-    period: 'Mai 2021 - Presente',
-    description: 'Referência técnica em ambientes de microsserviços (+50 Lambdas) utilizando Node.js, Kotlin e Java. Gerenciamento de incidentes críticos em produção (war rooms) e recuperação de sistemas legados instáveis. Forte atuação em CI/CD, mensageria (SQS/Kafka) e monitoramento (Datadog).'
+    period: 'Mai 2025 - Mar 2026',
+    description: 'Promovida a Especialista em reconhecimento à atuação como referência técnica. Referência técnica em ambiente de microsserviços com +50 Lambdas (Node.js, Kotlin, Java/Spring Boot), recuperação de sistema legado crítico em Kotlin e gerenciamento de incidentes P1/P2 em war rooms.'
+  },
+  {
+    role: 'Application Development Senior Analyst (Backend)',
+    company: 'Accenture',
+    period: 'Mai 2021 - Mai 2025',
+    description: 'Atuação em múltiplos projetos e clientes de consultoria. Upgrade de runtime Node.js (v12→v18), otimização de queries e análise de logs (CloudWatch), mensageria com SQS/Kafka, pipelines CI/CD (CodePipeline, GitHub Actions, Docker) e monitoramento com Datadog.'
   },
   {
     role: 'Engenheira de Software Full Stack',
@@ -17,9 +29,9 @@ export const experienceData = [
   },
   {
     role: 'Analista de Sistemas Full Stack',
-    company: 'Agência Zetta',
+    company: 'FUNDECC/LEMAF',
     period: 'Abr 2019 - Out 2020',
-    description: 'Desenvolvimento de APIs REST (.NET) e interfaces Angular. Gestão de branches complexas no GitLab, refinamento técnico como ponto focal Scrum e integração de gateways de pagamento governamentais.'
+    description: 'APIs REST em C# (.NET) com integrações a gateways de pagamento governamentais. Gestão de branches e deploys entre ambientes (DEV a PROD) e resolução de incidentes críticos em produção.'
   },
   {
     role: 'Analista de Sistemas',
@@ -30,8 +42,8 @@ export const experienceData = [
   {
     role: 'Professora Universitária',
     company: 'Universidade Federal de Lavras (UFLA)',
-    period: 'Nov 2013 - Mai 2015',
-    description: 'Lecionou disciplinas de arquitetura de software, algoritmos e banco de dados (SQL e NoSQL).'
+    period: 'Jan 2013 - Mai 2015',
+    description: 'Lecionou disciplinas de algoritmos, linguagens de programação e bancos de dados (SQL e NoSQL).'
   }
 ];
 
@@ -46,6 +58,12 @@ export const educationData = [
     company: 'Amazon Web Services (AWS)',
     period: 'Jun 2025',
     description: 'Competências: AWS'
+  },
+  {
+    role: 'AWS Certified Cloud Practitioner',
+    company: 'Amazon Web Services (AWS)',
+    period: '2024',
+    description: 'Certificação'
   },
   {
     role: 'Introducing Generative AI with AWS',
@@ -64,6 +82,12 @@ export const educationData = [
     period: 'Certificação'
   },
   {
+    role: 'Scrum Fundamentals',
+    company: 'SCRUMstudy',
+    period: '2017',
+    description: 'Certificação'
+  },
+  {
     role: 'Bertelsmann Data Science Challenge',
     company: 'Udacity',
     period: 'Mar 2022',
@@ -78,6 +102,34 @@ export const educationData = [
     role: 'Bacharelado em Sistemas de Informação',
     company: 'Anhanguera Educacional',
     period: 'Jan 2008 - Dez 2012'
+  },
+  {
+    role: 'Licenciatura em Matemática',
+    company: 'Faculdade Educacional da Lapa',
+    period: '2017'
+  }
+];
+
+export const publicationsData = [
+  {
+    title: 'O Cadastro Ambiental Rural (CAR) como instrumento de controle ambiental de uso e ocupação do imóvel rural',
+    venue: 'XXI ENGEMA — Encontro Internacional sobre Gestão Empresarial e Meio Ambiente',
+    period: 'Dez 2019'
+  },
+  {
+    title: 'Inovação aberta no setor público: como o Ministério da Educação utilizou o crowdstorming para impulsionar a prospecção de soluções inovadoras',
+    venue: 'Capítulo em "Inovação no setor público: teoria, tendências e casos no Brasil"',
+    period: 'Out 2017'
+  },
+  {
+    title: 'Non-invasive method to analyse the risk of developing diabetic foot',
+    venue: 'Healthcare Technology Letters',
+    period: 'Abr 2014'
+  },
+  {
+    title: 'Desenvolvimento de um Sistema Help Desk para a Universidade Vale do Rio Verde',
+    venue: 'Revista da Universidade Vale do Rio Verde',
+    period: 'Ago 2013'
   }
 ];
 
@@ -141,6 +193,12 @@ export const projectsData = [
     description: '<p>API RESTful em Java 21 focada em gerenciamento de usuários. Implementação central baseada em Arquitetura Hexagonal (Ports & Adapters) para isolamento do domínio de negócio.</p><ul style="margin-top: 10px; padding-left: 20px;"><li><strong>Segurança:</strong> Autenticação via Spring Security e JWT com RBAC estruturado.</li><li><strong>Qualidade:</strong> SOLID, MapStruct, tratamento global de exceções e testes automatizados.</li></ul>',
     stack: ['Java 21', 'Arquitetura Hexagonal', 'JWT', 'Spring Security', 'PostgreSQL'],
     link: 'https://github.com/fiap-tech-challenge-java/fiap-tech-challenge'
+  },
+  {
+    title: 'Equinox Solar CRM: Plataforma Full-Stack com NestJS, Next.js e Infra via Docker',
+    period: 'Mar 2023 - Dez 2023',
+    description: '<p>CRM full-stack para gestão comercial de projetos de energia solar, com back-end em NestJS e front-end em Next.js, ambiente totalmente containerizado com Docker.</p>',
+    stack: ['NestJS', 'Next.js', 'Docker']
   },
   {
     title: 'Kube Backend: API Node.js + PostgreSQL no Kubernetes',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import Servicos from '../views/Servicos.vue';
 import SobreCode from '../views/SobreCode.vue';
 import ExperienciaCode from '../views/ExperienciaCode.vue';
 import CertificacoesCode from '../views/CertificacoesCode.vue';
+import PublicacoesCode from '../views/PublicacoesCode.vue';
 import DeploymentsCode from '../views/DeploymentsCode.vue';
 import ContatoCode from '../views/ContatoCode.vue';
 
@@ -23,6 +24,7 @@ export const routes = [
   { path: '/sobre', name: 'sobre-code', component: SobreCode },
   { path: '/experiencia', name: 'experiencia-code', component: ExperienciaCode },
   { path: '/certificacoes', name: 'certificacoes-code', component: CertificacoesCode },
+  { path: '/publicacoes', name: 'publicacoes-code', component: PublicacoesCode },
   { path: '/projetos', name: 'deployments-code', component: DeploymentsCode },
   { path: '/contato', name: 'contato-code', component: ContatoCode },
 ];

--- a/src/views/DeploymentsCode.vue
+++ b/src/views/DeploymentsCode.vue
@@ -20,8 +20,8 @@ export default {
           title: project.title,
           period: project.period,
           stack: project.stack,
-          repo: project.link,
         };
+        if (project.link) entry.repo = project.link;
         if (project.liveUrl) entry.live = project.liveUrl;
         return entry;
       });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -31,36 +31,36 @@
     <section id="experience" aria-labelledby="experience-title">
       <h2 id="experience-title" class="section-title">Log de Execução Profissional</h2>
       <ol class="timeline">
-        <li v-for="item in experienceData" :key="item.role + item.company" class="timeline-item">
-          <span class="timeline-date">{{ item.period }}</span>
-          <h3 class="timeline-title">{{ item.role }}</h3>
-          <div class="timeline-org">{{ item.company }}</div>
-          <p v-if="item.description" class="timeline-desc">{{ item.description }}</p>
+        <li class="timeline-item">
+          <span class="timeline-date">{{ currentRole.period }}</span>
+          <h3 class="timeline-title">{{ currentRole.role }}</h3>
+          <div class="timeline-org">{{ currentRole.company }}</div>
+          <p v-if="currentRole.description" class="timeline-desc">{{ currentRole.description }}</p>
         </li>
       </ol>
+      <router-link to="/experiencia" class="btn-hud btn-hud--live">Ver histórico completo (experiencia.log) →</router-link>
     </section>
 
     <section id="education" aria-labelledby="education-title">
       <h2 id="education-title" class="section-title">Data Banks & Certificações</h2>
-      <ol class="timeline">
-        <li v-for="item in educationData" :key="item.role" class="timeline-item">
-          <span class="timeline-date">{{ item.period }}</span>
-          <h3 class="timeline-title">{{ item.role }}</h3>
-          <div class="timeline-org">{{ item.company }}</div>
-          <p v-if="item.description" class="timeline-desc" style="color: var(--accent-core); font-size: 0.85rem; margin-top: 4px;">{{ item.description }}</p>
-        </li>
-      </ol>
+      <div class="hud-card">
+        <p class="card-desc">
+          Pós-graduanda em Arquitetura e Desenvolvimento Java (FIAP), mestre em Engenharia de Sistemas e Automação (UFLA)
+          e certificações recentes em AWS, Machine Learning e Agentic AI.
+        </p>
+        <router-link to="/certificacoes" class="btn-hud btn-hud--live">Ver formação e certificações completas →</router-link>
+      </div>
     </section>
 
     <section id="publications" aria-labelledby="publications-title">
       <h2 id="publications-title" class="section-title">Publicações Acadêmicas</h2>
-      <ol class="timeline">
-        <li v-for="item in publicationsData" :key="item.title" class="timeline-item">
-          <span class="timeline-date">{{ item.period }}</span>
-          <h3 class="timeline-title">{{ item.title }}</h3>
-          <div class="timeline-org">{{ item.venue }}</div>
-        </li>
-      </ol>
+      <div class="hud-card">
+        <p class="card-desc">
+          {{ publicationsData.length }} publicações em conferências e periódicos científicos — de gestão ambiental e
+          inovação no setor público a saúde digital.
+        </p>
+        <router-link to="/publicacoes" class="btn-hud btn-hud--live">Ver publicações completas →</router-link>
+      </div>
     </section>
 
     <section id="projects" aria-labelledby="projects-title">
@@ -152,7 +152,7 @@
 
 <script>
 import ProjectPreviewModal from '../components/ProjectPreviewModal.vue';
-import { experienceData, educationData, publicationsData, projectsData } from '../data/profileData.js';
+import { experienceData, publicationsData, projectsData } from '../data/profileData.js';
 
 export default {
   name: 'Home',
@@ -161,10 +161,14 @@ export default {
     return {
       previewProject: null,
       experienceData,
-      educationData,
       publicationsData,
       projectsData,
     };
+  },
+  computed: {
+    currentRole() {
+      return this.experienceData[0];
+    },
   },
   methods: {
     openPreview(project) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -52,6 +52,17 @@
       </ol>
     </section>
 
+    <section id="publications" aria-labelledby="publications-title">
+      <h2 id="publications-title" class="section-title">Publicações Acadêmicas</h2>
+      <ol class="timeline">
+        <li v-for="item in publicationsData" :key="item.title" class="timeline-item">
+          <span class="timeline-date">{{ item.period }}</span>
+          <h3 class="timeline-title">{{ item.title }}</h3>
+          <div class="timeline-org">{{ item.venue }}</div>
+        </li>
+      </ol>
+    </section>
+
     <section id="projects" aria-labelledby="projects-title">
       <h2 id="projects-title" class="section-title">Deployments & Cases</h2>
       <div class="project-grid">
@@ -69,7 +80,7 @@
             <a v-if="project.liveUrl" :href="project.liveUrl" target="_blank" rel="noopener noreferrer" class="btn-hud btn-hud--live">
               Acessar App <span class="sr-only"> (Abre em uma nova aba)</span>
             </a>
-            <a :href="project.link" target="_blank" rel="noopener noreferrer" class="btn-hud">
+            <a v-if="project.link" :href="project.link" target="_blank" rel="noopener noreferrer" class="btn-hud">
               Repositório <span class="sr-only"> (Abre em uma nova aba)</span>
             </a>
             <button
@@ -141,7 +152,7 @@
 
 <script>
 import ProjectPreviewModal from '../components/ProjectPreviewModal.vue';
-import { experienceData, educationData, projectsData } from '../data/profileData.js';
+import { experienceData, educationData, publicationsData, projectsData } from '../data/profileData.js';
 
 export default {
   name: 'Home',
@@ -151,6 +162,7 @@ export default {
       previewProject: null,
       experienceData,
       educationData,
+      publicationsData,
       projectsData,
     };
   },

--- a/src/views/PublicacoesCode.vue
+++ b/src/views/PublicacoesCode.vue
@@ -1,0 +1,33 @@
+<template>
+  <main id="main-content">
+    <h2 class="section-title">publicacoes.log</h2>
+    <CodeFileView :lines="lines" />
+  </main>
+</template>
+
+<script>
+import CodeFileView from '../components/CodeFileView.vue';
+import { tok } from '../utils/codeLines.js';
+import { publicationsData } from '../data/profileData.js';
+
+export default {
+  name: 'PublicacoesCode',
+  components: { CodeFileView },
+  computed: {
+    lines() {
+      const lines = [];
+      publicationsData.forEach((item, i) => {
+        lines.push([
+          tok('[', 'punct'),
+          tok(item.period, 'num'),
+          tok('] ', 'punct'),
+          tok(item.title, 'heading'),
+        ]);
+        lines.push([tok('    // ', 'punct'), tok(item.venue, 'comment')]);
+        if (i < publicationsData.length - 1) lines.push([]);
+      });
+      return lines;
+    },
+  },
+};
+</script>


### PR DESCRIPTION
## Summary
- Adiciona o cargo atual na **Alice (health tech)** e separa a promoção na Accenture (Senior Analyst → Specialist), com data de saída em mar/2026
- Corrige o nome da empresa do cargo abr/2019–out/2020 para **FUNDECC/LEMAF** (era "Agência Zetta")
- Adiciona certificações que estavam faltando (**AWS Certified Cloud Practitioner**, **Scrum Fundamentals**) e a Licenciatura em Matemática
- Adiciona nova seção **Publicações Acadêmicas** (Home + `publicacoes.log` no sidebar da IDE), com as 4 publicações do LinkedIn
- Adiciona o projeto **Equinox Solar CRM** (NestJS/Next.js/Docker)
- Torna o link de repositório opcional na renderização de projetos (Home e `deployments.json`), já que nem todo projeto tem repo público
- Atualiza o README (perfil do GitHub) com o cargo atual e a nova certificação AWS

## Test plan
- [x] `npm run build` (vite build + SSR + prerender) roda sem erros
- [x] Conferido no HTML pré-renderizado que "Alice (health tech)", "Publicações Acadêmicas", "FUNDECC/LEMAF" e "Equinox Solar CRM" aparecem corretamente
- [ ] Revisão visual no browser da nova seção de Publicações e do card do projeto Equinox

https://claude.ai/code/session_01DsngwLduGivkWC4iqz5pwp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsngwLduGivkWC4iqz5pwp)_