### PR TITLE
feat: redesign GitHub profile with a stronger visual identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,109 @@
-# Rebeca Nonato
+<p align="center">
+  <img src="./assets/github-profile-header.svg" alt="Rebeca Nonato — Software Engineer, Backend & Distributed Systems" width="100%" />
+</p>
 
-**Software Engineer | Backend & Distributed Systems | Kotlin · Java · Node.js | AWS · Event-Driven**
+<p align="center">
+  <a href="https://rebecanonato89.dev"><strong>Portfólio</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://www.linkedin.com/in/rebecanonato89/"><strong>LinkedIn</strong></a>
+  &nbsp;·&nbsp;
+  <a href="mailto:rebecanonato89@gmail.com"><strong>Contato</strong></a>
+</p>
 
-Engenheira de Software com mais de 10 anos de experiência em desenvolvimento de sistemas, com trajetória em ambientes corporativos e produtos digitais de alta disponibilidade. Minha atuação combina backend, sistemas distribuídos, integração assíncrona, confiabilidade e evolução de sistemas em produção.
+<p align="center">
+  <img src="https://img.shields.io/badge/Kotlin-7F52FF?style=flat-square&logo=kotlin&logoColor=white" alt="Kotlin" />
+  <img src="https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=openjdk&logoColor=white" alt="Java" />
+  <img src="https://img.shields.io/badge/Node.js-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js" />
+  <img src="https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white" alt="AWS" />
+  <img src="https://img.shields.io/badge/Kafka-231F20?style=flat-square&logo=apachekafka&logoColor=white" alt="Kafka" />
+  <img src="https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white" alt="Kubernetes" />
+</p>
 
-Atualmente atuo em health tech com backend em Kotlin/JVM, features end-to-end, sistemas orientados a eventos, confiabilidade de produção e colaboração cross-team. Antes disso, na Accenture, atuei como referência técnica em ambientes de microsserviços e serverless na AWS, com Node.js, Kotlin e Java/Spring Boot, incluindo sustentação de sistemas críticos, incidentes P1/P2, observabilidade e modernização de aplicações.
+## Engenharia que me interessa
 
-Este GitHub concentra projetos públicos que demonstram decisões de arquitetura, qualidade de código, mensageria, testes automatizados, DDD, Clean/Hexagonal Architecture e uso aplicado de IA em engenharia de software.
+Engenheira de Software com **10+ anos em desenvolvimento de sistemas**, hoje concentrada em backend, sistemas distribuídos, integração assíncrona e confiabilidade de produção. Trabalho principalmente com **Kotlin/JVM, Java, Node.js/TypeScript e AWS**, conectando decisões de arquitetura ao comportamento real do sistema em produção.
 
-[Portfólio](https://rebecanonato89.dev) · [LinkedIn](https://www.linkedin.com/in/rebecanonato89/) · [Email](mailto:rebecanonato89@gmail.com)
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>Backend & Domain</strong><br/><br/>
+      Kotlin · Java · Node.js<br/>
+      Spring Boot · NestJS<br/>
+      DDD · Clean · Hexagonal
+    </td>
+    <td width="33%" valign="top">
+      <strong>Distributed Systems</strong><br/><br/>
+      Kafka · SQS · Event-Driven<br/>
+      CQRS · Outbox Pattern<br/>
+      Idempotência · DLQ
+    </td>
+    <td width="33%" valign="top">
+      <strong>Cloud & Reliability</strong><br/><br/>
+      AWS · Docker · Kubernetes<br/>
+      CI/CD · Datadog<br/>
+      CloudWatch · Incidentes
+    </td>
+  </tr>
+</table>
+
+## Selected engineering work
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <h3><a href="https://github.com/fiap-tech-challenge-java/clinicfiapp-monorepo">ClinicFiapApp</a></h3>
+      <p><strong>Distributed backend · FIAP</strong></p>
+      <p>Comunicação assíncrona com Kafka, CQRS, Outbox Pattern, consumidores idempotentes e estratégia de falhas com DLQ.</p>
+      <code>Java</code> <code>Spring</code> <code>Kafka</code> <code>CQRS</code>
+    </td>
+    <td width="50%" valign="top">
+      <h3><a href="https://github.com/rebecanonato89/food-fiapp">Food Fiapp</a></h3>
+      <p><strong>Architecture & quality · FIAP</strong></p>
+      <p>Clean Architecture protegida por ArchUnit, testes unitários e de integração e quality gate de cobertura no build.</p>
+      <code>Java 21</code> <code>Spring Boot</code> <code>ArchUnit</code> <code>PostgreSQL</code>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h3><a href="https://github.com/rebecanonato89/hedge-cli">Hedge CLI</a></h3>
+      <p><strong>Software engineering research</strong></p>
+      <p>Pipeline híbrido de análise estática + LLM para detectar Eager Test em código Java, usando AST, heurísticas e ensemble.</p>
+      <code>Python</code> <code>tree-sitter</code> <code>AST</code> <code>LLMs</code>
+    </td>
+    <td width="50%" valign="top">
+      <h3><a href="https://github.com/rebecanonato89/quotes-service">Quotes Service</a></h3>
+      <p><strong>Kotlin domain modeling · Personal lab</strong></p>
+      <p>Modelagem de domínio, validação funcional com Either, eventos de domínio e execução assíncrona com coroutines.</p>
+      <code>Kotlin</code> <code>Spring Boot</code> <code>DDD</code> <code>Coroutines</code>
+    </td>
+  </tr>
+</table>
+
+<details>
+  <summary><strong>Mais projetos de arquitetura e infraestrutura</strong></summary>
+  <br/>
+
+  - **[TechChallenge](https://github.com/rebecanonato89/fiap-tech-challenge)** — Java 21, Arquitetura Hexagonal, Spring Security, JWT/RBAC, PostgreSQL e OpenAPI.
+  - **[Kube Backend](https://github.com/rebecanonato89/kube-backend)** — Node.js/PostgreSQL containerizado e executado localmente com Docker e Kubernetes.
+  - **AllRev SaaS** — produto multi-tenant com backend privado; o case público está disponível no [portfólio](https://rebecanonato89.dev).
+  - **ConcursoTrack, Equinox Solar CRM e Arcade** — evidências complementares de produto e implementação disponíveis no portfólio.
+</details>
+
+## Experiência em uma linha
+
+`Health tech / Kotlin & Event-Driven` → `Accenture / distributed & serverless AWS` → `backend, integrações e sistemas corporativos`
+
+Além da implementação de features, minha atuação inclui evolução de sistemas em produção, observabilidade, incidentes críticos, code review, decisões de arquitetura e colaboração entre engenharia e produto.
+
+## Formação & pesquisa
+
+- **Especialização em Arquitetura e Desenvolvimento Java** — FIAP, 2024–2026
+- **Mestrado em Engenharia de Sistemas e Automação** — UFLA
+- Publicações em tecnologia, inovação e engenharia; detalhes no [portfólio](https://rebecanonato89.dev)
+- Formação complementar em AWS, Machine Learning, Generative AI e Agentic AI
 
 ---
 
-## Stack principal
-
-* **Backend:** Kotlin, Java, Node.js/TypeScript, Spring Boot, NestJS.
-* **Sistemas distribuídos:** Kafka, SQS, Event-Driven Architecture, CQRS, Outbox Pattern, idempotência e DLQ.
-* **Cloud & Operações:** AWS (Lambda, ECS, EKS, EC2), Docker, Kubernetes, CI/CD, Datadog e CloudWatch.
-* **Arquitetura & Qualidade:** DDD, Clean Architecture, Hexagonal Architecture, TDD, JUnit, ArchUnit, PostgreSQL e RBAC.
-* **IA aplicada à engenharia:** análise estática + LLM gating, automação de fluxo de desenvolvimento e AI-assisted coding.
-
----
-
-## Projetos prioritários
-
-| Projeto | Contexto | O que demonstra | Stack principal |
-| :--- | :--- | :--- | :--- |
-| **[ClinicFiapApp](https://github.com/fiap-tech-challenge-java/clinicfiapp-monorepo)** | Acadêmico — FIAP | Backend distribuído com comunicação assíncrona, Outbox Pattern, CQRS, consumidores idempotentes e tratamento de falhas com DLQ. | Java, Spring, Kafka, CQRS |
-| **[Food Fiapp](https://github.com/rebecanonato89/food-fiapp)** | Acadêmico — FIAP | Clean Architecture validada com ArchUnit, testes unitários e de integração e quality gate de cobertura no build. | Java 21, Spring Boot, PostgreSQL, MinIO, Docker |
-| **[Hedge CLI](https://github.com/rebecanonato89/hedge-cli)** | Projeto independente | Análise estática de testes Java com AST, heurística, LLM gating e ensemble para detecção de Eager Test. | Python, tree-sitter, AST, LLMs |
-| **[Quotes Service](https://github.com/rebecanonato89/quotes-service)** | Projeto pessoal | Modelagem de domínio em Kotlin, validação funcional com Either, eventos de domínio e coroutines. | Kotlin, Spring Boot, DDD, Coroutines |
-| **[TechChallenge](https://github.com/rebecanonato89/fiap-tech-challenge)** | Acadêmico — FIAP | API Java com Arquitetura Hexagonal, domínio isolado, Spring Security, JWT/RBAC e contratos OpenAPI. | Java 21, Spring Boot, PostgreSQL |
-| **[Kube Backend](https://github.com/rebecanonato89/kube-backend)** | Laboratório técnico | Containerização e execução local de uma API Node.js/PostgreSQL no Kubernetes, com ConfigMap, Secret e Services. | Node.js, PostgreSQL, Docker, Kubernetes |
-
-Essa é a ordem recomendada para os repositórios públicos fixados no perfil.
-
----
-
-## Projetos complementares
-
-**AllRev SaaS** continua relevante como case de produto multi-tenant, mas o repositório de backend é privado e por isso não deve ocupar um dos slots públicos fixados. **ConcursoTrack**, **Equinox Solar CRM** e os experimentos do Arcade permanecem como evidência complementar no portfólio.
-
----
-
-## Formação e certificações
-
-* **Especialização em Arquitetura e Desenvolvimento Java** — FIAP, 2024–2026
-* **Mestrado em Engenharia de Sistemas e Automação** — UFLA
-* **AWS Educate Machine Learning Foundations** — AWS, 2025
-* **Introducing Generative AI with AWS** — Udacity, 2025
-* **Reinvention with Agentic AI** — Accenture, 2025
+<p align="center">
+  <sub>Mais contexto, experiência completa, publicações e projetos em <a href="https://rebecanonato89.dev">rebecanonato89.dev</a>.</sub>
+</p>

--- a/assets/github-profile-header.svg
+++ b/assets/github-profile-header.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" viewBox="0 0 1200 320" role="img" aria-labelledby="title desc">
+  <title id="title">Rebeca Nonato — Software Engineer</title>
+  <desc id="desc">Banner profissional com foco em Backend, Distributed Systems, Event-Driven e Cloud.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="55%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="50%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1200" height="320" rx="28" fill="url(#bg)"/>
+  <circle cx="1060" cy="40" r="170" fill="#2563eb" opacity="0.10"/>
+  <circle cx="1130" cy="290" r="150" fill="#06b6d4" opacity="0.08"/>
+  <g opacity="0.9">
+    <path d="M850 74 H970 L1018 122 H1118" fill="none" stroke="#334155" stroke-width="2"/>
+    <path d="M874 158 H960 L1008 206 H1110" fill="none" stroke="#334155" stroke-width="2"/>
+    <path d="M930 94 V222" fill="none" stroke="#334155" stroke-width="2"/>
+    <circle cx="850" cy="74" r="7" fill="#60a5fa" filter="url(#glow)"/>
+    <circle cx="970" cy="74" r="7" fill="#818cf8"/>
+    <circle cx="1018" cy="122" r="7" fill="#22d3ee"/>
+    <circle cx="1118" cy="122" r="7" fill="#60a5fa"/>
+    <circle cx="874" cy="158" r="7" fill="#22d3ee"/>
+    <circle cx="960" cy="158" r="7" fill="#818cf8"/>
+    <circle cx="1008" cy="206" r="7" fill="#60a5fa"/>
+    <circle cx="1110" cy="206" r="7" fill="#22d3ee"/>
+    <circle cx="930" cy="222" r="7" fill="#818cf8"/>
+  </g>
+  <text x="72" y="92" fill="#94a3b8" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="22" font-weight="600" letter-spacing="3">SOFTWARE ENGINEER</text>
+  <text x="72" y="156" fill="#f8fafc" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="54" font-weight="700">Rebeca Nonato</text>
+  <rect x="72" y="181" width="560" height="4" rx="2" fill="url(#accent)"/>
+  <text x="72" y="228" fill="#cbd5e1" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="24" font-weight="500">Backend · Distributed Systems · Event-Driven · Cloud</text>
+  <text x="72" y="268" fill="#94a3b8" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="19">Kotlin · Java · Node.js · AWS · Kafka · Architecture</text>
+</svg>


### PR DESCRIPTION
## Objetivo
Deixar o GitHub visualmente mais forte e coerente com o posicionamento de Software Engineer focada em Backend & Distributed Systems, sem cair em excesso de badges, widgets ou elementos típicos de perfil júnior.

## Alterações
- adiciona header SVG próprio com identidade visual técnica;
- reorganiza o README para reduzir aparência de currículo seco;
- cria navegação visual para Portfólio, LinkedIn e Contato;
- adiciona stack principal com badges discretos;
- transforma áreas técnicas em blocos visuais de Backend, Distributed Systems e Cloud & Reliability;
- apresenta os principais projetos em cards de duas colunas;
- move projetos complementares para uma seção recolhível;
- compacta experiência e formação para priorizar evidência técnica.

## Arquivos
- `README.md`
- `assets/github-profile-header.svg`

## Direção visual
Profissional, técnica e sóbria, com azul/indigo/ciano como acentos. Sem contadores, troféus, snake animation ou widgets de atividade.
