### PR TITLE
feat: refine portfolio layout and align GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,106 +4,91 @@
 
 <p align="center">
   <a href="https://rebecanonato89.dev"><strong>Portfólio</strong></a>
-  &nbsp;·&nbsp;
+  &nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="https://www.linkedin.com/in/rebecanonato89/"><strong>LinkedIn</strong></a>
-  &nbsp;·&nbsp;
+  &nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="mailto:rebecanonato89@gmail.com"><strong>Contato</strong></a>
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/Kotlin-7F52FF?style=flat-square&logo=kotlin&logoColor=white" alt="Kotlin" />
-  <img src="https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=openjdk&logoColor=white" alt="Java" />
-  <img src="https://img.shields.io/badge/Node.js-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js" />
-  <img src="https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white" alt="AWS" />
-  <img src="https://img.shields.io/badge/Kafka-231F20?style=flat-square&logo=apachekafka&logoColor=white" alt="Kafka" />
-  <img src="https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white" alt="Kubernetes" />
-</p>
+## About
 
-## Engenharia que me interessa
+Software Engineer com **10+ anos construindo, modernizando e sustentando sistemas backend**. Foco atual em sistemas distribuídos, arquitetura orientada a eventos, confiabilidade e evolução de software.
 
-Engenheira de Software com **10+ anos em desenvolvimento de sistemas**, hoje concentrada em backend, sistemas distribuídos, integração assíncrona e confiabilidade de produção. Trabalho principalmente com **Kotlin/JVM, Java, Node.js/TypeScript e AWS**, conectando decisões de arquitetura ao comportamento real do sistema em produção.
+Trabalho principalmente com **Kotlin, Java, Node.js/TypeScript e AWS**, conectando decisões de arquitetura ao comportamento real dos sistemas em produção.
+
+## Selected Engineering Work
 
 <table>
   <tr>
-    <td width="33%" valign="top">
-      <strong>Backend & Domain</strong><br/><br/>
-      Kotlin · Java · Node.js<br/>
-      Spring Boot · NestJS<br/>
-      DDD · Clean · Hexagonal
+    <td colspan="2" valign="top">
+      <h3>01 · <a href="https://github.com/fiap-tech-challenge-java/clinicfiapp-monorepo">ClinicFiapApp</a></h3>
+      <p><strong>Academic collaborative project</strong></p>
+      <p>Backend distribuído com comunicação assíncrona, consistência confiável e leitura orientada a eventos.</p>
+      <code>Java</code> <code>Spring</code> <code>Kafka</code> <code>CQRS</code> <code>Outbox</code> <code>Idempotency</code> <code>DLQ</code>
     </td>
-    <td width="33%" valign="top">
-      <strong>Distributed Systems</strong><br/><br/>
-      Kafka · SQS · Event-Driven<br/>
-      CQRS · Outbox Pattern<br/>
-      Idempotência · DLQ
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>02 · <a href="https://github.com/fiap-tech-challenge-java/food-fiapp">Food Fiapp</a></h3>
+      <p><strong>Academic project</strong></p>
+      <p>Clean Architecture protegida por regras automatizadas e quality gate no build.</p>
+      <code>Java 21</code> <code>Spring Boot</code> <code>Clean Architecture</code> <code>ArchUnit</code>
     </td>
-    <td width="33%" valign="top">
-      <strong>Cloud & Reliability</strong><br/><br/>
-      AWS · Docker · Kubernetes<br/>
-      CI/CD · Datadog<br/>
-      CloudWatch · Incidentes
+    <td width="50%" valign="top">
+      <h3>03 · <a href="https://github.com/rebecanonato89/hedge-cli">Hedge CLI</a></h3>
+      <p><strong>Independent Software Engineering Research</strong></p>
+      <p>Análise estática seletivamente combinada a LLM para detectar Eager Test em código Java.</p>
+      <code>Static Analysis</code> <code>AST</code> <code>Heuristics</code> <code>LLM</code>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>04 · <a href="https://github.com/rebecanonato89/quotes-service">Quotes Service</a></h3>
+      <p><strong>Personal project</strong></p>
+      <p>Modelagem de regras de negócio, eventos de domínio e processamento assíncrono.</p>
+      <code>Kotlin</code> <code>DDD</code> <code>Coroutines</code> <code>Domain Events</code>
+    </td>
+    <td width="50%" valign="top">
+      <h3>05 · <a href="https://github.com/fiap-tech-challenge-java/fiap-tech-challenge">TechChallenge</a></h3>
+      <p><strong>Academic project</strong></p>
+      <p>Domínio isolado por Arquitetura Hexagonal, com autenticação e autorização.</p>
+      <code>Java 21</code> <code>Hexagonal Architecture</code> <code>Spring Security</code> <code>JWT</code>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2" valign="top">
+      <h3>06 · <a href="https://github.com/rebecanonato89/kube-backend">Kube Backend</a></h3>
+      <p><strong>Infrastructure lab</strong></p>
+      <p>API Node.js/Express e PostgreSQL executados em Kubernetes local com recursos declarativos de infraestrutura.</p>
+      <code>Node.js</code> <code>Express</code> <code>Docker</code> <code>Kubernetes</code> <code>PostgreSQL</code>
     </td>
   </tr>
 </table>
 
-## Selected engineering work
+## Engineering Capabilities
 
 <table>
   <tr>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/fiap-tech-challenge-java/clinicfiapp-monorepo">ClinicFiapApp</a></h3>
-      <p><strong>Distributed backend · FIAP</strong></p>
-      <p>Comunicação assíncrona com Kafka, CQRS, Outbox Pattern, consumidores idempotentes e estratégia de falhas com DLQ.</p>
-      <code>Java</code> <code>Spring</code> <code>Kafka</code> <code>CQRS</code>
-    </td>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rebecanonato89/food-fiapp">Food Fiapp</a></h3>
-      <p><strong>Architecture & quality · FIAP</strong></p>
-      <p>Clean Architecture protegida por ArchUnit, testes unitários e de integração e quality gate de cobertura no build.</p>
-      <code>Java 21</code> <code>Spring Boot</code> <code>ArchUnit</code> <code>PostgreSQL</code>
-    </td>
+    <td width="33%" valign="top"><strong>Backend</strong><br/><br/>Kotlin · Java · Node.js<br/>Spring Boot · NestJS<br/>PostgreSQL</td>
+    <td width="34%" valign="top"><strong>Distributed Systems</strong><br/><br/>Kafka · SQS · Event-Driven<br/>CQRS · Outbox<br/>Idempotency · DLQ</td>
+    <td width="33%" valign="top"><strong>Architecture</strong><br/><br/>DDD · Clean Architecture<br/>Hexagonal · Microservices<br/>Multi-Tenant</td>
   </tr>
   <tr>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rebecanonato89/hedge-cli">Hedge CLI</a></h3>
-      <p><strong>Software engineering research</strong></p>
-      <p>Pipeline híbrido de análise estática + LLM para detectar Eager Test em código Java, usando AST, heurísticas e ensemble.</p>
-      <code>Python</code> <code>tree-sitter</code> <code>AST</code> <code>LLMs</code>
-    </td>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rebecanonato89/quotes-service">Quotes Service</a></h3>
-      <p><strong>Kotlin domain modeling · Personal lab</strong></p>
-      <p>Modelagem de domínio, validação funcional com Either, eventos de domínio e execução assíncrona com coroutines.</p>
-      <code>Kotlin</code> <code>Spring Boot</code> <code>DDD</code> <code>Coroutines</code>
-    </td>
+    <td colspan="2" valign="top"><strong>Cloud & Reliability</strong><br/><br/>AWS · Docker · Kubernetes · Datadog · CloudWatch · CI/CD</td>
+    <td valign="top"><strong>Engineering Quality</strong><br/><br/>TDD · Automated Tests · ArchUnit · Observability · Code Review</td>
   </tr>
 </table>
 
-<details>
-  <summary><strong>Mais projetos de arquitetura e infraestrutura</strong></summary>
-  <br/>
+## Experience, briefly
 
-  - **[TechChallenge](https://github.com/rebecanonato89/fiap-tech-challenge)** — Java 21, Arquitetura Hexagonal, Spring Security, JWT/RBAC, PostgreSQL e OpenAPI.
-  - **[Kube Backend](https://github.com/rebecanonato89/kube-backend)** — Node.js/PostgreSQL containerizado e executado localmente com Docker e Kubernetes.
-  - **AllRev SaaS** — produto multi-tenant com backend privado; o case público está disponível no [portfólio](https://rebecanonato89.dev).
-  - **ConcursoTrack, Equinox Solar CRM e Arcade** — evidências complementares de produto e implementação disponíveis no portfólio.
-</details>
+`Health tech / Kotlin & Event-Driven` → `Accenture / distributed & serverless AWS` → `backend, integrations & corporate systems`
 
-## Experiência em uma linha
+Minha trajetória inclui evolução de sistemas em produção, observabilidade, incidentes, code review, decisões de arquitetura e colaboração entre engenharia e produto. A experiência completa está no [portfólio](https://rebecanonato89.dev/#experiencia) e no [LinkedIn](https://www.linkedin.com/in/rebecanonato89/).
 
-`Health tech / Kotlin & Event-Driven` → `Accenture / distributed & serverless AWS` → `backend, integrações e sistemas corporativos`
+## Built for humans and machines
 
-Além da implementação de features, minha atuação inclui evolução de sistemas em produção, observabilidade, incidentes críticos, code review, decisões de arquitetura e colaboração entre engenharia e produto.
-
-## Formação & pesquisa
-
-- **Especialização em Arquitetura e Desenvolvimento Java** — FIAP, 2024–2026
-- **Mestrado em Engenharia de Sistemas e Automação** — UFLA
-- Publicações em tecnologia, inovação e engenharia; detalhes no [portfólio](https://rebecanonato89.dev)
-- Formação complementar em AWS, Machine Learning, Generative AI e Agentic AI
-
----
+O [portfólio](https://rebecanonato89.dev) foi estruturado para pessoas, mecanismos de busca e agentes: **Accessibility · Structured Data · JSON Resume · LLM-readable · Prerendered content**.
 
 <p align="center">
-  <sub>Mais contexto, experiência completa, publicações e projetos em <a href="https://rebecanonato89.dev">rebecanonato89.dev</a>.</sub>
+  <sub>Backend · Distributed Systems · Event-Driven · Cloud & Reliability</sub>
 </p>

--- a/assets/github-profile-header.svg
+++ b/assets/github-profile-header.svg
@@ -3,9 +3,9 @@
   <desc id="desc">Banner profissional com foco em Backend, Distributed Systems, Event-Driven e Cloud.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="55%" stop-color="#111827"/>
-      <stop offset="100%" stop-color="#172554"/>
+      <stop offset="0%" stop-color="#080d18"/>
+      <stop offset="55%" stop-color="#0d1524"/>
+      <stop offset="100%" stop-color="#111c2e"/>
     </linearGradient>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#60a5fa"/>
@@ -38,5 +38,5 @@
   <text x="72" y="156" fill="#f8fafc" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="54" font-weight="700">Rebeca Nonato</text>
   <rect x="72" y="181" width="560" height="4" rx="2" fill="url(#accent)"/>
   <text x="72" y="228" fill="#cbd5e1" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="24" font-weight="500">Backend · Distributed Systems · Event-Driven · Cloud</text>
-  <text x="72" y="268" fill="#94a3b8" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="19">Kotlin · Java · Node.js · AWS · Kafka · Architecture</text>
+  <text x="72" y="268" fill="#94a3b8" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="19">I build backend systems that need to keep working.</text>
 </svg>

--- a/src/App.vue
+++ b/src/App.vue
@@ -232,6 +232,7 @@ export default {
   --bg-base: #f7f9fc;
   --bg-surface: #eef2f8;
   --bg-surface-raised: #ffffff;
+  --bg-alternate: #f1f5fa;
   --text-main: #101828;
   --text-muted: #475467;
   --text-subtle: #667085;
@@ -269,6 +270,7 @@ export default {
   --bg-base: #080d18;
   --bg-surface: #0d1524;
   --bg-surface-raised: #111c2e;
+  --bg-alternate: #0b1321;
   --text-main: #f0f5ff;
   --text-muted: #a8b5ca;
   --text-subtle: #7d8da7;
@@ -308,6 +310,7 @@ export default {
   --bg-base: #000000;
   --bg-surface: #000000;
   --bg-surface-raised: #0a0a0a;
+  --bg-alternate: #000000;
   --text-main: #ffffff;
   --text-muted: #f2f2f2;
   --accent-core: #ffd60a;
@@ -437,7 +440,8 @@ html { scroll-behavior: smooth; }
   border-bottom: 1px solid var(--accent-border);
 }
 .site-header-inner {
-  max-width: 1100px;
+  width: calc(100% - 96px);
+  max-width: 1480px;
   margin: 0 auto;
   padding: var(--space-sm) var(--space-md);
   display: flex;
@@ -490,7 +494,7 @@ html { scroll-behavior: smooth; }
 .nav-link:hover { background: var(--accent-dim); color: var(--accent-core); }
 .nav-link--active { color: var(--accent-core); font-weight: 700; }
 
-@media (max-width: 780px) {
+@media (max-width: 1080px) {
   .nav-toggle { display: inline-flex; align-items: center; justify-content: center; }
   .primary-nav {
     display: none;
@@ -506,6 +510,18 @@ html { scroll-behavior: smooth; }
   .nav-divider { display: none; }
   .site-header { position: relative; }
   .nav-link { padding: 0.65rem 0.4rem; border-bottom: 1px solid var(--accent-border); border-radius: 0; }
+}
+
+@media (max-width: 1366px) {
+  .site-header-inner, .site-footer-inner, .footer-note { width: calc(100% - 64px); }
+}
+
+@media (max-width: 1024px) {
+  .site-header-inner, .site-footer-inner, .footer-note { width: calc(100% - 40px); }
+}
+
+@media (max-width: 700px) {
+  .site-header-inner, .site-footer-inner, .footer-note { width: calc(100% - 32px); }
 }
 
 /* =========================================================================
@@ -680,7 +696,8 @@ section:last-child { margin-bottom: 0; }
   padding: var(--space-xl) var(--space-md) var(--space-lg);
 }
 .site-footer-inner {
-  max-width: 1100px;
+  width: calc(100% - 96px);
+  max-width: 1480px;
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -693,7 +710,8 @@ section:last-child { margin-bottom: 0; }
 .footer-links a { color: var(--text-main); text-decoration: none; }
 .footer-links a:hover { color: var(--accent-core); text-decoration: underline; }
 .footer-note {
-  max-width: 1100px;
+  width: calc(100% - 96px);
+  max-width: 1480px;
   margin: var(--space-lg) auto 0;
   padding-top: var(--space-md);
   border-top: 1px solid var(--accent-border);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,7 +24,7 @@
     <section id="projetos" class="section projects" aria-labelledby="projetos-title">
       <header class="section-heading"><div><p class="eyebrow">Selected Engineering Work</p><h2 id="projetos-title">Projetos em Destaque</h2></div><p>Decisões de engenharia documentadas em código público — do domínio ao deploy.</p></header>
       <div class="projects-layout">
-        <article v-for="(project, index) in featuredProjects" :key="project.title" class="project-card" :class="{ lead: index === 0 }">
+        <article v-for="(project, index) in featuredProjects" :key="project.title" class="project-card" :class="{ lead: index === 0, closing: index === featuredProjects.length - 1 }">
           <div class="project-index" aria-hidden="true">0{{ index + 1 }}</div>
           <div class="project-content">
             <div class="project-meta"><span>{{ projectContext(project.title) }}</span><time>{{ project.period }}</time></div>
@@ -40,7 +40,7 @@
 
     <section id="sobre" class="section about" aria-labelledby="sobre-title"><div class="section-heading compact"><p class="eyebrow">Profile</p><h2 id="sobre-title">Engenharia para sistemas reais.</h2></div><div class="about-copy"><p>{{ aboutData.paragraphs[0] }}</p><p>{{ aboutData.paragraphs[1] }}</p></div></section>
 
-    <section id="experiencia" class="section" aria-labelledby="experiencia-title">
+    <section id="experiencia" class="section surface-alt" aria-labelledby="experiencia-title">
       <header class="section-heading"><div><p class="eyebrow">Experience</p><h2 id="experiencia-title">Trajetória profissional</h2></div><p>Mais de 10 anos construindo, modernizando e sustentando sistemas.</p></header>
       <ol class="career"><li v-for="job in experienceData" :key="job.role + job.company + job.period"><i aria-hidden="true"></i><time>{{ job.period }}</time><div><div class="career-title"><h3>{{ job.role }}</h3><span v-if="job.evolution">{{ job.evolution }}</span></div><p class="company">{{ job.company }}</p><p>{{ compactExperience(job) }}</p></div></li></ol>
     </section>
@@ -50,7 +50,7 @@
       <div class="skills"><article v-for="group in domainSkills" :key="group.category"><span aria-hidden="true">{{ group.number }}</span><h3>{{ group.category }}</h3><p>{{ group.primary }}</p><ul class="tech-list" :aria-label="group.category"><li v-for="item in group.items" :key="item">{{ item }}</li></ul></article></div>
     </section>
 
-    <section class="section compact-area" aria-label="Formação e publicações">
+    <section class="section compact-area surface-alt" aria-label="Formação e publicações">
       <div id="certificacoes"><div class="section-heading compact"><p class="eyebrow">Learning</p><h2>Formação &amp; Certificações</h2></div><ul class="compact-list"><li v-for="edu in educationData" :key="edu.role + edu.company"><div><strong>{{ edu.role }}</strong><span>{{ edu.company }}</span></div><time>{{ edu.period }}</time></li></ul></div>
       <div id="publicacoes"><div class="section-heading compact"><p class="eyebrow">Writing</p><h2>Publicações</h2></div><ul class="compact-list"><li v-for="pub in publicationsData" :key="pub.title"><div><strong>{{ pub.title }}</strong><span>{{ pub.venue }}</span></div><time>{{ pub.period }}</time></li></ul></div>
     </section>
@@ -65,7 +65,7 @@
 import { basicsData, aboutData, experienceData, educationData, publicationsData, projectsData, contactData } from '../data/profileData.js';
 const FEATURED = ['ClinicFiapApp - Microsserviços de Agendamento Hospitalar','Food Fiapp: API de Gestão de Restaurantes','Hedge CLI: Análise Estática + IA para Eager Test','Quotes Service: Cotação e Emissão de Apólices','TechChallenge: API de Gestão de Usuários','Kube Backend: API Node.js + PostgreSQL no Kubernetes'];
 const CONTEXT = { ClinicFiapApp: 'Projeto acadêmico colaborativo', Food: 'Projeto acadêmico', Hedge: 'Independent Software Engineering Research', Quotes: 'Projeto pessoal · MVP', TechChallenge: 'Projeto acadêmico', Kube: 'Laboratório de infraestrutura' };
-const FLOWS = { ClinicFiapApp: ['API','Command','Kafka','Consumer','Outbox','Database'], Food: ['HTTP','Use Case','Domain','Adapter'], Hedge: ['Java tests','AST','Heuristics','LLM gate','Ensemble'], Quotes: ['Quote','Domain rules','Event','Coroutine'] };
+const FLOWS = { ClinicFiapApp: ['API','Command','Kafka','Consumer','Outbox','Database'], Food: ['HTTP','Use Case','Domain','Adapter'], Hedge: ['Java tests','AST','Heuristics','LLM gate','Ensemble'], Quotes: ['Quote','Domain rules','Event','Coroutine'], Kube: ['Application','Docker','Kubernetes','PostgreSQL'] };
 export default {
   name: 'Home', data() { return { basicsData, aboutData, experienceData, educationData, publicationsData, projectsData, contactData }; },
   computed: {
@@ -94,4 +94,23 @@ main{overflow:hidden}.hero{max-width:1240px;min-height:620px;margin:auto;padding
 .about{display:grid;grid-template-columns:.8fr 1.2fr;gap:5rem}.about-copy{display:grid;gap:1.2rem;color:var(--text-muted);font-size:1.08rem}.about-copy p{margin:0}.career{margin:0;padding:0;list-style:none}.career li{position:relative;padding:0 0 2.4rem 2rem;display:grid;grid-template-columns:180px minmax(0,1fr);gap:2rem}.career li:before{content:'';position:absolute;left:4px;top:12px;bottom:-12px;width:1px;background:var(--accent-border)}.career li:last-child:before{display:none}.career>li>i{position:absolute;left:0;top:8px;width:9px;height:9px;border:2px solid var(--accent-core);border-radius:50%;background:var(--bg-base)}.career time{color:var(--text-subtle);font:.73rem var(--font-code)}.career-title{display:flex;flex-wrap:wrap;align-items:center;gap:.7rem}.career-title h3{margin:0;font-size:1.05rem}.career-title span{padding:.16rem .45rem;border-radius:999px;background:var(--accent-dim);color:var(--accent-cyan);font:.65rem var(--font-code)}.career .company{margin:.18rem 0 .45rem;color:var(--accent-core);font-weight:700}.career li>div>p:last-child{max-width:76ch;margin:0;color:var(--text-muted);font-size:.92rem}.skills{display:grid;grid-template-columns:repeat(6,1fr);gap:1rem}.skills article{grid-column:span 2;padding:1.5rem;border-top:2px solid var(--accent-core);background:var(--bg-surface)}.skills article:nth-child(4),.skills article:nth-child(5){grid-column:span 3}.skills article>span{color:var(--accent-soft);font:700 .75rem var(--font-code)}.skills h3{margin:1.5rem 0 .5rem}.skills p{margin:0;color:var(--text-muted)}
 .compact-area{max-width:1240px;display:grid;grid-template-columns:1fr 1fr;gap:4rem}.compact-list{margin:0;padding:0;list-style:none}.compact-list li{padding:.85rem 0;border-bottom:1px solid var(--accent-border);display:flex;justify-content:space-between;gap:1rem}.compact-list strong,.compact-list span{display:block}.compact-list strong{font:650 .86rem var(--font-ui)}.compact-list span,.compact-list time{color:var(--text-subtle);font-size:.72rem}.compact-list time{flex:0 0 auto;font-family:var(--font-code)}.machine{margin-block:2.5rem;padding:clamp(2rem,4vw,3rem);border:1px solid var(--accent-border);border-radius:18px;display:grid;grid-template-columns:1fr 1fr;gap:3rem;background:var(--bg-surface)}.machine h2{margin:0 0 1rem;font-size:clamp(1.8rem,3vw,2.7rem)}.machine p{max-width:57ch;margin:0;color:var(--text-muted)}.machine ul{margin:0;padding:0;display:grid;grid-template-columns:1fr 1fr;gap:.7rem;list-style:none}.machine li{padding:.65rem .8rem;border-left:2px solid var(--accent-core);background:var(--bg-surface-raised);font:.74rem var(--font-code)}.contact{max-width:1180px;margin:3.5rem auto 0;padding:clamp(3.5rem,7vw,6rem) 1.5rem;text-align:center}.contact>p:not(.eyebrow){max-width:56ch;margin:1.2rem auto 0;color:var(--text-muted)}.contact .actions{justify-content:center}
 @media(max-width:900px){.hero{min-height:auto;grid-template-columns:1fr;padding-top:4rem}.system-visual{max-width:540px;margin:auto}.about{grid-template-columns:1fr;gap:1rem}.skills article{grid-column:span 3}.skills article:last-child{grid-column:1/-1}.compact-area{gap:2rem}.mini-flow i{display:none}.mini-flow span{flex:1 1 90px;text-align:center}}@media(max-width:700px){.section-heading,.compact-area,.machine{grid-template-columns:1fr;gap:1.25rem}.projects-layout{grid-template-columns:1fr}.project-card.lead{grid-column:auto;display:block}.career li{grid-template-columns:1fr;gap:.4rem}.skills{grid-template-columns:1fr}.skills article,.skills article:nth-child(4),.skills article:nth-child(5),.skills article:last-child{grid-column:auto}}@media(max-width:430px){.hero,.section,.contact{padding-left:1rem;padding-right:1rem}.hero h1{font-size:clamp(2.4rem,12vw,3rem)}.actions .button{width:100%}.system-visual{margin-inline:-1rem}.project-meta{display:block}.project-meta time,.compact-list time{display:block;margin-top:.35rem}.compact-list li{display:block}.machine ul{grid-template-columns:1fr}.mini-flow span{flex-basis:100%}}@media print{.system-visual,.actions,.resume-links{display:none}.hero{min-height:0}}
+
+/* Wide editorial layout and subtle section rhythm. */
+main{max-width:none;margin:0;padding:0}
+.hero{width:calc(100% - 96px);max-width:1480px;padding-inline:0;grid-template-columns:minmax(0,1.15fr) minmax(380px,.85fr);gap:clamp(3rem,6vw,6rem)}
+.hero .actions{flex-wrap:nowrap}
+.section{width:calc(100% - 96px);max-width:1400px;padding:clamp(3.1rem,4.5vw,4.5rem) 0}
+.projects,.surface-alt{background:var(--bg-alternate);box-shadow:0 0 0 100vmax var(--bg-alternate);clip-path:inset(0 -100vmax)}
+.projects,.compact-area{max-width:1480px}
+.project-card.lead,.project-card.closing{grid-column:1/-1;display:grid;grid-template-columns:100px minmax(0,1fr)}
+.project-description{max-width:78ch}
+.mini-flow{display:flex;flex-wrap:wrap;overflow:visible}
+.mini-flow span{min-width:0;flex:1 1 76px;white-space:normal;text-align:center}
+.mini-flow i{flex:0 0 auto;text-align:center}
+.contact{width:calc(100% - 96px);max-width:1480px;border-radius:20px;background:var(--bg-alternate)}
+@media(max-width:1366px){.hero,.section,.contact{width:calc(100% - 64px)}.hero{gap:3rem}.hero h1{font-size:clamp(2.8rem,5.25vw,4.65rem)}}
+@media(max-width:1024px){.hero,.section,.contact{width:calc(100% - 40px)}.hero{grid-template-columns:minmax(0,1.15fr) minmax(300px,.85fr);gap:2rem}.hero .button{padding-inline:.8rem}.site-header-inner,.site-footer-inner,.footer-note{width:calc(100% - 40px)}}
+@media(max-width:900px){.hero{grid-template-columns:1fr}.hero .actions{flex-wrap:wrap}.project-card.closing{display:block}.mini-flow{grid-template-columns:repeat(2,minmax(0,1fr))}.mini-flow i{display:none}}
+@media(max-width:700px){.hero,.section,.contact{width:calc(100% - 32px)}.project-card.lead{display:block}.site-header-inner,.site-footer-inner,.footer-note{width:calc(100% - 32px)}}
+@media(max-width:430px){.hero,.section,.contact{padding-left:0;padding-right:0}.mini-flow{grid-template-columns:1fr}.system-visual{margin-inline:0}}
 </style>


### PR DESCRIPTION
## Resumo

- amplia a largura útil do portfólio em desktop e notebook
- mantém os quatro CTAs do hero na mesma linha quando há espaço
- corrige a restrição global que limitava a Home a 880px
- transforma Kube Backend no fechamento full-width da grade
- torna os diagramas responsivos sem scroll horizontal
- adiciona alternância sutil de superfícies entre grandes seções
- preserva a navegação principal e separa visualmente o ecossistema do site
- alinha o README e seu header SVG à identidade final do portfólio

## README

- preserva header, links principais, About e experiência compacta
- promove os seis Selected Engineering Work na mesma ordem do site
- destaca ClinicFiapApp e usa Kube Backend como fechamento horizontal
- organiza cinco domínios de Engineering Capabilities
- adiciona Built for humans and machines de forma discreta

## Validação

- npm ci
- npm run build
- Vite, SSR e prerender concluídos
- inspeção local em 1920, 1440, 1366, 1024, 768 e regras específicas de 390px
- metadata e OG PNG verificados
- resume.json, resume.md, llms.txt, sitemap, robots e JSON-LD verificados
- busca por textos antigos e apresentação incorreta de Hedge revisada

Nenhum repositório ou código da organização Alice Health foi acessado ou incluído.