### PR TITLE
fix: scope dark filter to monochrome logos

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -329,23 +329,23 @@ export default {
 }
 
 :root[data-theme='dark'] {
-  --bg-base: #080d18;
-  --bg-surface: #0d1524;
-  --bg-surface-raised: #111c2e;
-  --bg-alternate: #0b1321;
-  --text-main: #f0f5ff;
-  --text-muted: #a8b5ca;
-  --text-subtle: #7d8da7;
-  --accent-core: #6f8cff;
-  --accent-hover: #91a7ff;
-  --accent-cyan: #55d7e5;
-  --accent-soft: #40506c;
+  --bg-base: #080D18;
+  --bg-surface: #0D1524;
+  --bg-surface-raised: #111C2E;
+  --bg-alternate: #0B1321;
+  --text-main: #F0F5FF;
+  --text-muted: #A8B5CA;
+  --text-subtle: #7D8DA7;
+  --accent-core: #6F8CFF;
+  --accent-hover: #91A7FF;
+  --accent-cyan: #55D7E5;
+  --accent-soft: #40506C;
   --accent-glow: rgba(69, 102, 240, 0.24);
   --accent-dim: rgba(111, 140, 255, 0.13);
-  --accent-border: #26344b;
-  --code-bg: #09111f;
-  --status-ok: #4bd6a2;
-  --button-text: #07101d;
+  --accent-border: #26344B;
+  --code-bg: #09111F;
+  --status-ok: #4BD6A2;
+  --button-text: #07101D;
   --card-shadow: rgba(0, 0, 0, 0.45);
   --scrim-overlay: rgba(0, 0, 0, 0.7);
   color-scheme: dark;

--- a/src/App.vue
+++ b/src/App.vue
@@ -310,6 +310,7 @@ export default {
   --button-text: #ffffff;
   --card-shadow: rgba(15, 23, 42, 0.08);
   --scrim-overlay: rgba(15, 23, 42, 0.6);
+  --mono-logo-filter: none;
 
   --radius-sm: 6px;
   --radius-md: 12px;
@@ -348,6 +349,7 @@ export default {
   --button-text: #07101D;
   --card-shadow: rgba(0, 0, 0, 0.45);
   --scrim-overlay: rgba(0, 0, 0, 0.7);
+  --mono-logo-filter: invert(1);
   color-scheme: dark;
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -121,6 +121,6 @@ main{max-width:none;margin:0;padding:0}
 .skill-logos img{width:22px;height:22px;object-fit:contain}
 .button svg{width:1rem;height:1rem;fill:currentColor;flex:0 0 auto;margin-right:.45rem}.skill-symbol{display:block;width:30px;height:30px;margin:1rem 0 .2rem;color:var(--accent-cyan)}.skill-symbol svg{width:100%;height:100%;fill:none;stroke:currentColor;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round}.skills article:nth-child(3) .skill-symbol{color:var(--accent-core)}.skills article:nth-child(4) .skill-symbol{color:var(--accent-cyan)}.skills article:nth-child(5) .skill-symbol{color:var(--accent-core)}
 :global(.back-to-top){position:fixed;right:clamp(1rem,3vw,2rem);bottom:clamp(1rem,3vw,2rem);z-index:20;width:2.75rem;height:2.75rem;border:1px solid var(--accent-border);border-radius:999px;background:var(--bg-surface-raised);color:var(--text-main);font-size:1.3rem;line-height:1;box-shadow:0 8px 24px var(--card-shadow);cursor:pointer;transition:background .2s,border-color .2s,transform .2s}.back-to-top:hover{border-color:var(--accent-core);background:var(--accent-dim);transform:translateY(-2px)}
-:global(:root[data-theme='dark']) .tech-logo--mono{filter:invert(1)}
+.tech-logo--mono{filter:var(--mono-logo-filter)}
 @media(max-width:700px){.tech-strip{gap:.7rem .9rem}.tech-logo-item img{width:16px;height:16px}}
 </style>


### PR DESCRIPTION
## Summary
- remove the scoped global root selector that propagated filter inversion to the document element
- define a global theme token for monochrome logo filtering
- apply the filter only to .tech-logo--mono images

## Validation
- npm run build
- Chrome computed-style checks for light, dark, light high contrast, and dark high contrast
- document.documentElement filter remains none in all four modes
- Java/Kafka monochrome logos use none in light and invert(1) in dark
- non-monochrome images remain unfiltered
- dark background remains navy (rgb(8, 13, 24))